### PR TITLE
feat: i18n (PT-BR/EN) + PiP theme inheritance

### DIFF
--- a/components/atoms/ChallengeBrowser.vue
+++ b/components/atoms/ChallengeBrowser.vue
@@ -5,8 +5,8 @@
         <svg class="w-5 h-5 text-warning" fill="currentColor" viewBox="0 0 24 24">
           <path d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z" />
         </svg>
-        <h3 class="font-semibold text-sm">Todos os Challenges</h3>
-        <span class="badge badge-sm badge-ghost ml-auto">{{ challenges.allChallenges.length }} disponiveis</span>
+        <h3 class="font-semibold text-sm">{{ $t('challenges.allChallenges') }}</h3>
+        <span class="badge badge-sm badge-ghost ml-auto">{{ $t('challenges.available', { count: challenges.allChallenges.length }) }}</span>
       </div>
 
       <div class="space-y-2 max-h-96 overflow-y-auto pr-1">
@@ -22,7 +22,7 @@
             </span>
             <div>
               <span class="font-medium text-sm capitalize">{{ challenge.label }}</span>
-              <span class="text-xs text-base-content/50 ml-2">{{ challenge.items.length }} challenges</span>
+              <span class="text-xs text-base-content/50 ml-2">{{ challenge.items.length }} {{ $t('challenges.challenges') }}</span>
             </div>
           </div>
           <div class="collapse-content">
@@ -47,22 +47,13 @@
 import { computed } from 'vue'
 import { useChallengesStore, type Challenge } from '~/stores/challenges'
 
+const { t } = useI18n()
 const challenges = useChallengesStore()
 
 interface GroupedChallenge {
   type: string
   label: string
   items: Challenge[]
-}
-
-const typeLabels: Record<string, string> = {
-  body: 'Alongamento',
-  eye: 'Exercicio Ocular',
-  drink: 'Hidratacao',
-  breathe: 'Respiracao',
-  posture: 'Postura',
-  meditate: 'Meditacao Rapida',
-  walk: 'Caminhada',
 }
 
 const groupedChallenges = computed<GroupedChallenge[]>(() => {
@@ -78,7 +69,7 @@ const groupedChallenges = computed<GroupedChallenge[]>(() => {
     if (items && items.length > 0) {
       result.push({
         type,
-        label: typeLabels[type] || type,
+        label: t(`challengeTypes.${type}`),
         items,
       })
     }

--- a/components/atoms/CompletedChallenges.vue
+++ b/components/atoms/CompletedChallenges.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="stat bg-base-100 rounded-box shadow-sm p-4">
-    <div class="stat-title">Completed challenges</div>
+    <div class="stat-title">{{ $t('challenges.completedChallenges') }}</div>
     <div class="stat-value text-primary text-3xl">{{ challenges.completedChallenges }}</div>
   </div>
 </template>

--- a/components/atoms/LanguageSelector.vue
+++ b/components/atoms/LanguageSelector.vue
@@ -35,7 +35,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 
 const { locales, locale, setLocale: setI18nLocale } = useI18n()
 
@@ -52,6 +52,13 @@ function setLocale(code: string) {
     localStorage.setItem('pomodoro-locale', code)
   }
 }
+
+// Keep local state in sync if i18n locale changes from elsewhere
+watch(locale, (newLocale) => {
+  if (currentLocale.value !== newLocale) {
+    currentLocale.value = newLocale
+  }
+})
 
 onMounted(() => {
   if (import.meta.client) {

--- a/components/atoms/LanguageSelector.vue
+++ b/components/atoms/LanguageSelector.vue
@@ -12,7 +12,7 @@
         <button
           v-for="locale in availableLocales"
           :key="locale.code"
-          class="w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-all duration-200"
+          class="w-full flex items-baseline gap-3 px-3 py-2 rounded-lg transition-all duration-200"
           :class="currentLocale === locale.code
             ? 'bg-primary/10 ring-1 ring-primary/30'
             : 'hover:bg-base-200'"
@@ -22,7 +22,7 @@
           <span class="text-sm font-medium flex-1 text-left">{{ locale.name }}</span>
           <svg
             v-if="currentLocale === locale.code"
-            class="w-4 h-4 text-primary"
+            class="w-4 h-4 text-primary self-center"
             fill="currentColor"
             viewBox="0 0 20 20"
           >

--- a/components/atoms/LanguageSelector.vue
+++ b/components/atoms/LanguageSelector.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="card bg-base-100 shadow-sm">
+    <div class="card-body p-4">
+      <div class="flex items-center gap-2 mb-3">
+        <svg class="w-5 h-5 text-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129" />
+        </svg>
+        <h3 class="font-semibold text-sm">{{ $t('nav.language') }}</h3>
+      </div>
+
+      <div class="space-y-1">
+        <button
+          v-for="locale in availableLocales"
+          :key="locale.code"
+          class="w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-all duration-200"
+          :class="currentLocale === locale.code
+            ? 'bg-primary/10 ring-1 ring-primary/30'
+            : 'hover:bg-base-200'"
+          @click="setLocale(locale.code)"
+        >
+          <span class="text-xl">{{ locale.code === 'pt-BR' ? '🇧🇷' : '🇺🇸' }}</span>
+          <span class="text-sm font-medium flex-1 text-left">{{ locale.name }}</span>
+          <svg
+            v-if="currentLocale === locale.code"
+            class="w-4 h-4 text-primary"
+            fill="currentColor"
+            viewBox="0 0 20 20"
+          >
+            <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+const { locales, locale, setLocale: setI18nLocale } = useI18n()
+
+const currentLocale = ref(locale.value)
+
+const availableLocales = computed(() => {
+  return locales.value as Array<{ code: string; name: string }>
+})
+
+function setLocale(code: string) {
+  currentLocale.value = code
+  setI18nLocale(code)
+  if (import.meta.client) {
+    localStorage.setItem('pomodoro-locale', code)
+  }
+}
+
+onMounted(() => {
+  if (import.meta.client) {
+    const saved = localStorage.getItem('pomodoro-locale')
+    if (saved && availableLocales.value.some(l => l.code === saved)) {
+      setLocale(saved)
+    }
+  }
+})
+</script>

--- a/components/atoms/LevelUpModal.vue
+++ b/components/atoms/LevelUpModal.vue
@@ -10,11 +10,11 @@
           <svg class="w-16 h-16 mx-auto mb-4 text-warning" fill="currentColor" viewBox="0 0 24 24">
             <path d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z" />
           </svg>
-          <h3 class="text-2xl font-bold">Congratulations!</h3>
-          <p class="py-2 text-base-content/70">You reached a new level!</p>
+          <h3 class="text-2xl font-bold">{{ $t('levelUp.congratulations') }}</h3>
+          <p class="py-2 text-base-content/70">{{ $t('levelUp.newLevel') }}</p>
         </div>
         <div class="modal-action justify-center">
-          <button class="btn btn-primary" @click="challenges.setIsLevelUpModalOpen(false)">Continue</button>
+          <button class="btn btn-primary" @click="challenges.setIsLevelUpModalOpen(false)">{{ $t('levelUp.continue') }}</button>
         </div>
       </div>
       <form method="dialog" class="modal-backdrop">

--- a/components/atoms/PiPWindow.vue
+++ b/components/atoms/PiPWindow.vue
@@ -4,7 +4,7 @@
     class="btn btn-circle shadow-lg fixed bottom-4 right-4 z-[9998]"
     :class="isOpen ? 'btn-error' : 'btn-primary'"
     @click="togglePiP"
-    :title="isOpen ? 'Fechar janela flutuante' : 'Abrir janela flutuante'"
+    :title="isOpen ? $t('pip.closeWindow') : $t('pip.openWindow')"
   >
     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path v-if="!isOpen" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
@@ -14,16 +14,33 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onUnmounted } from 'vue'
+import { ref, watch, onUnmounted } from 'vue'
 import { useCountdownStore } from '~/stores/countdown'
 import { useChallengesStore } from '~/stores/challenges'
+import { useThemeStore } from '~/stores/theme'
 
+const { t, locale } = useI18n()
 const countdown = useCountdownStore()
 const challenges = useChallengesStore()
+const themeStore = useThemeStore()
 const isOpen = ref(false)
 
 let pipWindow: any = null
 let animFrameId: number | null = null
+
+// Watch for theme changes and update PiP
+watch(() => themeStore.currentTheme, () => {
+  if (isOpen.value && pipWindow) {
+    updatePiPTheme()
+  }
+})
+
+// Watch for locale changes and update PiP
+watch(() => locale.value, () => {
+  if (isOpen.value && pipWindow) {
+    updatePiPContent()
+  }
+})
 
 function togglePiP() {
   if (isOpen.value) {
@@ -49,7 +66,7 @@ async function openPiP() {
       const styles = document.querySelectorAll('link[rel="stylesheet"], style')
       styles.forEach(style => pipWindow.document.head.appendChild(style.cloneNode(true)))
 
-      // Injetar CSS customizado
+      // Injetar CSS customizado com tema DaisyUI
       const customStyle = pipWindow.document.createElement('style')
       customStyle.textContent = getPiPCSS()
       pipWindow.document.head.appendChild(customStyle)
@@ -57,6 +74,9 @@ async function openPiP() {
       // Injetar HTML
       pipWindow.document.body.innerHTML = getPiPBody()
       pipWindow.document.title = 'Pomodoro'
+
+      // Sincronizar tema DaisyUI
+      syncDaisyUITheme()
 
       // Configurar eventos
       setupPiPEvents()
@@ -83,7 +103,7 @@ async function openPiP() {
   pipWindow = window.open('', 'pomodoro-pip', 'width=340,height=380')
 
   if (!pipWindow || pipWindow.closed) {
-    alert('Permita popups para usar a janela flutuante')
+    alert(t('pip.allowPopups'))
     return
   }
 
@@ -134,33 +154,146 @@ function updatePiPLoop() {
   }
 
   if (statusEl) {
-    statusEl.textContent = countdown.isActive ? 'Em andamento' : 'Pausado'
-    statusEl.style.color = countdown.isActive ? '#22c55e' : '#9ca3af'
+    statusEl.textContent = countdown.isActive ? t('pip.inProgress') : t('pip.paused')
   }
 
   if (toggleBtn) {
-    toggleBtn.textContent = countdown.isActive ? 'Parar' : 'Iniciar'
-    const btn = toggleBtn as HTMLButtonElement
-    btn.style.background = countdown.isActive
-      ? 'linear-gradient(135deg, #ef4444, #dc2626)'
-      : 'linear-gradient(135deg, #6366f1, #7c3aed)'
+    toggleBtn.textContent = countdown.isActive ? t('pip.stop') : t('pip.start')
   }
 
   if (challengeText) {
     challengeText.textContent = challenges.currentChallenge
       ? challenges.currentChallenge.description
-      : 'Inicie um ciclo para receber desafios'
+      : t('pip.startForChallenges')
   }
 
   animFrameId = requestAnimationFrame(updatePiPLoop)
+}
+
+function updatePiPContent() {
+  if (!pipWindow || pipWindow.closed) return
+
+  const challengeHeader = pipWindow.document.querySelector('.pip-challenge-header')
+  if (challengeHeader) {
+    challengeHeader.textContent = t('pip.challenge')
+  }
+
+  const statusEl = pipWindow.document.getElementById('pip-status')
+  if (statusEl) {
+    statusEl.textContent = countdown.isActive ? t('pip.inProgress') : t('pip.paused')
+  }
+
+  const toggleBtn = pipWindow.document.getElementById('pip-toggle-btn')
+  if (toggleBtn) {
+    toggleBtn.textContent = countdown.isActive ? t('pip.stop') : t('pip.start')
+  }
+
+  const resetBtn = pipWindow.document.getElementById('pip-reset-btn')
+  if (resetBtn) {
+    resetBtn.textContent = t('pip.reset')
+  }
+
+  const challengeText = pipWindow.document.getElementById('pip-challenge-text')
+  if (challengeText && !challenges.currentChallenge) {
+    challengeText.textContent = t('pip.startForChallenges')
+  }
+}
+
+function syncDaisyUITheme() {
+  if (!pipWindow || pipWindow.closed) return
+
+  // Copy data-theme attribute
+  const dataTheme = document.documentElement.getAttribute('data-theme')
+  if (dataTheme) {
+    pipWindow.document.documentElement.setAttribute('data-theme', dataTheme)
+  }
+
+  // Get computed CSS variables from the parent document
+  const rootStyles = getComputedStyle(document.documentElement)
+
+  // Extract DaisyUI theme colors
+  const themeVars = [
+    '--p', '--pc', '--s', '--sc', '--a', '--ac',
+    '--n', '--nc', '--b1', '--b2', '--b3', '--bc',
+    '--inc', '--suc', '--wa', '--er', '--in',
+    '--su', '--wa', '--er',
+  ]
+
+  let cssVars = ''
+  for (const varName of themeVars) {
+    const value = rootStyles.getPropertyValue(varName).trim()
+    if (value) {
+      cssVars += `${varName}: ${value};\n`
+    }
+  }
+
+  // Update or create style element with theme variables
+  let themeStyleEl = pipWindow.document.getElementById('pip-theme-vars')
+  if (!themeStyleEl) {
+    themeStyleEl = pipWindow.document.createElement('style')
+    themeStyleEl.id = 'pip-theme-vars'
+    pipWindow.document.head.appendChild(themeStyleEl)
+  }
+
+  // Get background and text colors based on theme
+  const bgColor = rootStyles.getPropertyValue('--b1').trim() || 'oklch(var(--b1))'
+  const textColor = rootStyles.getPropertyValue('--bc').trim() || 'oklch(var(--bc))'
+  const primaryColor = rootStyles.getPropertyValue('--p').trim() || 'oklch(var(--p))'
+  const primaryContent = rootStyles.getPropertyValue('--pc').trim() || 'oklch(var(--pc))'
+
+  themeStyleEl.textContent = `
+    :root {
+      ${cssVars}
+    }
+    body {
+      background: oklch(${bgColor}) !important;
+      color: oklch(${textColor}) !important;
+    }
+    .pip-timer {
+      background: linear-gradient(135deg, oklch(${primaryColor}), oklch(${primaryColor} / 0.8)) !important;
+      -webkit-background-clip: text !important;
+      -webkit-text-fill-color: transparent !important;
+      background-clip: text !important;
+    }
+    .pip-status {
+      color: oklch(${textColor} / 0.6) !important;
+    }
+    .pip-btn-primary {
+      background: linear-gradient(135deg, oklch(${primaryColor}), oklch(${primaryColor} / 0.9)) !important;
+      color: oklch(${primaryContent}) !important;
+    }
+    .pip-btn-ghost {
+      background: oklch(${bgColor} / 0.1) !important;
+      border: 1px solid oklch(${textColor} / 0.1) !important;
+      color: oklch(${textColor} / 0.6) !important;
+    }
+    .pip-btn-ghost:hover {
+      background: oklch(${bgColor} / 0.2) !important;
+      color: oklch(${textColor}) !important;
+    }
+    .pip-challenge {
+      background: oklch(${bgColor} / 0.5) !important;
+      border: 1px solid oklch(${textColor} / 0.1) !important;
+    }
+    .pip-challenge-header {
+      color: oklch(${primaryColor}) !important;
+    }
+    .pip-challenge-text {
+      color: oklch(${textColor} / 0.7) !important;
+    }
+  `
+}
+
+function updatePiPTheme() {
+  syncDaisyUITheme()
 }
 
 function getPiPCSS(): string {
   return `
     body {
       font-family: 'Inter', -apple-system, sans-serif !important;
-      background: #0f0f1a !important;
-      color: #e8e6e3 !important;
+      background: oklch(var(--b1, 15% 0 0)) !important;
+      color: oklch(var(--bc, 95% 0 0)) !important;
       margin: 0 !important;
       padding: 20px !important;
       display: flex !important;
@@ -174,15 +307,15 @@ function getPiPBody(): string {
   return `
     <div class="pip-timer-wrapper">
       <div class="pip-timer" id="pip-timer">${countdown.minutes}:${String(countdown.seconds).padStart(2, '0')}</div>
-      <div class="pip-status" id="pip-status">${countdown.isActive ? 'Em andamento' : 'Pausado'}</div>
+      <div class="pip-status" id="pip-status">${countdown.isActive ? t('pip.inProgress') : t('pip.paused')}</div>
     </div>
     <div class="pip-controls">
-      <button class="pip-btn pip-btn-primary" id="pip-toggle-btn">${countdown.isActive ? 'Parar' : 'Iniciar'}</button>
-      <button class="pip-btn pip-btn-ghost" id="pip-reset-btn">Reset</button>
+      <button class="pip-btn pip-btn-primary" id="pip-toggle-btn">${countdown.isActive ? t('pip.stop') : t('pip.start')}</button>
+      <button class="pip-btn pip-btn-ghost" id="pip-reset-btn">${t('pip.reset')}</button>
     </div>
     <div class="pip-challenge">
-      <div class="pip-challenge-header">Desafio</div>
-      <p class="pip-challenge-text" id="pip-challenge-text">${challenges.currentChallenge ? challenges.currentChallenge.description : 'Inicie um ciclo para receber desafios'}</p>
+      <div class="pip-challenge-header">${t('pip.challenge')}</div>
+      <p class="pip-challenge-text" id="pip-challenge-text">${challenges.currentChallenge ? challenges.currentChallenge.description : t('pip.startForChallenges')}</p>
     </div>
     <style>${getPiPStyles()}</style>
   `
@@ -197,12 +330,12 @@ function getPiPStyles(): string {
       font-weight: 700;
       letter-spacing: 3px;
       line-height: 1;
-      background: linear-gradient(135deg, #6366f1, #8b5cf6);
+      background: linear-gradient(135deg, oklch(var(--p)), oklch(var(--p) / 0.8));
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
       background-clip: text;
     }
-    .pip-status { font-size: 13px; font-weight: 500; margin-top: 6px; color: #9ca3af; }
+    .pip-status { font-size: 13px; font-weight: 500; margin-top: 6px; color: oklch(var(--bc) / 0.6); }
     .pip-controls { display: flex; gap: 10px; justify-content: center; margin: 20px 0; }
     .pip-btn {
       padding: 12px 28px;
@@ -215,34 +348,34 @@ function getPiPStyles(): string {
       font-family: 'Inter', sans-serif;
     }
     .pip-btn:hover { transform: translateY(-2px); box-shadow: 0 6px 16px rgba(0,0,0,0.3); }
-    .pip-btn-primary { background: linear-gradient(135deg, #6366f1, #7c3aed); color: white; }
+    .pip-btn-primary { background: linear-gradient(135deg, oklch(var(--p)), oklch(var(--p) / 0.9)); color: oklch(var(--pc)); }
     .pip-btn-ghost {
-      background: rgba(255,255,255,0.05);
-      border: 1px solid rgba(255,255,255,0.1);
-      color: #9ca3af;
+      background: oklch(var(--b1) / 0.1);
+      border: 1px solid oklch(var(--bc) / 0.1);
+      color: oklch(var(--bc) / 0.6);
     }
-    .pip-btn-ghost:hover { background: rgba(255,255,255,0.1); color: #fff; }
+    .pip-btn-ghost:hover { background: oklch(var(--b1) / 0.2); color: oklch(var(--bc)); }
     .pip-challenge {
-      background: rgba(255,255,255,0.03);
-      border: 1px solid rgba(255,255,255,0.05);
+      background: oklch(var(--b1) / 0.5);
+      border: 1px solid oklch(var(--bc) / 0.1);
       border-radius: 14px;
       padding: 16px;
       flex: 1;
     }
     .pip-challenge-header {
       font-weight: 600; font-size: 11px;
-      color: #a78bfa;
+      color: oklch(var(--p));
       margin-bottom: 10px;
       text-transform: uppercase;
       letter-spacing: 1.5px;
     }
-    .pip-challenge-text { font-size: 14px; color: #9ca3af; line-height: 1.6; }
+    .pip-challenge-text { font-size: 14px; color: oklch(var(--bc) / 0.7); line-height: 1.6; }
   `
 }
 
 function getFullHTML(): string {
   return `<!DOCTYPE html>
-<html>
+<html data-theme="${themeStore.currentTheme}">
 <head>
   <title>Pomodoro</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Rajdhani:wght@600;700&display=swap" rel="stylesheet">
@@ -250,8 +383,8 @@ function getFullHTML(): string {
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
       font-family: 'Inter', -apple-system, sans-serif;
-      background: #0f0f1a;
-      color: #e8e6e3;
+      background: oklch(var(--b1, 15% 0 0));
+      color: oklch(var(--bc, 95% 0 0));
       min-height: 100vh;
       padding: 20px;
       display: flex;

--- a/components/atoms/PiPWindow.vue
+++ b/components/atoms/PiPWindow.vue
@@ -7,7 +7,7 @@
     :title="isOpen ? $t('pip.closeWindow') : $t('pip.openWindow')"
   >
     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path v-if="!isOpen" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+      <path v-if="!isOpen" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2 4a2 2 0 012-2h16a2 2 0 012 2v12a2 2 0 01-2 2h-7l3 2v1H8v-1l3-2H4a2 2 0 01-2-2V4zm10 9h6a1 1 0 001-1V6a1 1 0 00-1-1h-6a1 1 0 00-1 1v6a1 1 0 001 1z" />
       <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
     </svg>
   </button>

--- a/components/atoms/PiPWindow.vue
+++ b/components/atoms/PiPWindow.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, onUnmounted } from 'vue'
+import { ref, watch, onUnmounted, nextTick } from 'vue'
 import { useCountdownStore } from '~/stores/countdown'
 import { useChallengesStore } from '~/stores/challenges'
 import { useThemeStore } from '~/stores/theme'
@@ -28,10 +28,12 @@ const isOpen = ref(false)
 let pipWindow: any = null
 let animFrameId: number | null = null
 
-// Watch for theme changes and update PiP
+// Watch for theme changes and update PiP (with nextTick for CSS recalc)
 watch(() => themeStore.currentTheme, () => {
   if (isOpen.value && pipWindow) {
-    updatePiPTheme()
+    nextTick(() => {
+      updatePiPTheme()
+    })
   }
 })
 
@@ -75,7 +77,8 @@ async function openPiP() {
       pipWindow.document.body.innerHTML = getPiPBody()
       pipWindow.document.title = 'Pomodoro'
 
-      // Sincronizar tema DaisyUI
+      // Wait for browser to recalculate CSS before syncing theme
+      await nextTick()
       syncDaisyUITheme()
 
       // Configurar eventos

--- a/components/atoms/PiPWindow.vue
+++ b/components/atoms/PiPWindow.vue
@@ -199,6 +199,18 @@ function updatePiPContent() {
   }
 }
 
+/**
+ * Strips oklch() wrapper from a CSS value string.
+ * DaisyUI custom properties (--p, --b1, etc.) contain raw OKLCH component
+ * values (e.g. "0.933 0.018 272.8"), but getComputedStyle may return them
+ * already wrapped as "oklch(0.933 0.018 272.8)". We extract just the values.
+ */
+function extractOklchValues(raw: string): string {
+  const trimmed = raw.trim()
+  const match = trimmed.match(/^oklch\((.+)\)$/i)
+  return match ? match[1].trim() : trimmed
+}
+
 function syncDaisyUITheme() {
   if (!pipWindow || pipWindow.closed) return
 
@@ -211,19 +223,19 @@ function syncDaisyUITheme() {
   // Get computed CSS variables from the parent document
   const rootStyles = getComputedStyle(document.documentElement)
 
-  // Extract DaisyUI theme colors
+  // Extract DaisyUI theme colors - these are raw OKLCH component values
   const themeVars = [
     '--p', '--pc', '--s', '--sc', '--a', '--ac',
     '--n', '--nc', '--b1', '--b2', '--b3', '--bc',
     '--inc', '--suc', '--wa', '--er', '--in',
-    '--su', '--wa', '--er',
+    '--su',
   ]
 
   let cssVars = ''
   for (const varName of themeVars) {
-    const value = rootStyles.getPropertyValue(varName).trim()
-    if (value) {
-      cssVars += `${varName}: ${value};\n`
+    const raw = rootStyles.getPropertyValue(varName).trim()
+    if (raw) {
+      cssVars += `${varName}: ${extractOklchValues(raw)};\n`
     }
   }
 
@@ -235,51 +247,45 @@ function syncDaisyUITheme() {
     pipWindow.document.head.appendChild(themeStyleEl)
   }
 
-  // Get background and text colors based on theme
-  const bgColor = rootStyles.getPropertyValue('--b1').trim() || 'oklch(var(--b1))'
-  const textColor = rootStyles.getPropertyValue('--bc').trim() || 'oklch(var(--bc))'
-  const primaryColor = rootStyles.getPropertyValue('--p').trim() || 'oklch(var(--p))'
-  const primaryContent = rootStyles.getPropertyValue('--pc').trim() || 'oklch(var(--pc))'
-
   themeStyleEl.textContent = `
     :root {
       ${cssVars}
     }
     body {
-      background: oklch(${bgColor}) !important;
-      color: oklch(${textColor}) !important;
+      background: oklch(var(--b1)) !important;
+      color: oklch(var(--bc)) !important;
     }
     .pip-timer {
-      background: linear-gradient(135deg, oklch(${primaryColor}), oklch(${primaryColor} / 0.8)) !important;
+      background: linear-gradient(135deg, oklch(var(--p)), oklch(var(--p) / 0.8)) !important;
       -webkit-background-clip: text !important;
       -webkit-text-fill-color: transparent !important;
       background-clip: text !important;
     }
     .pip-status {
-      color: oklch(${textColor} / 0.6) !important;
+      color: oklch(var(--bc) / 0.6) !important;
     }
     .pip-btn-primary {
-      background: linear-gradient(135deg, oklch(${primaryColor}), oklch(${primaryColor} / 0.9)) !important;
-      color: oklch(${primaryContent}) !important;
+      background: linear-gradient(135deg, oklch(var(--p)), oklch(var(--p) / 0.9)) !important;
+      color: oklch(var(--pc)) !important;
     }
     .pip-btn-ghost {
-      background: oklch(${bgColor} / 0.1) !important;
-      border: 1px solid oklch(${textColor} / 0.1) !important;
-      color: oklch(${textColor} / 0.6) !important;
+      background: oklch(var(--b1) / 0.1) !important;
+      border: 1px solid oklch(var(--bc) / 0.1) !important;
+      color: oklch(var(--bc) / 0.6) !important;
     }
     .pip-btn-ghost:hover {
-      background: oklch(${bgColor} / 0.2) !important;
-      color: oklch(${textColor}) !important;
+      background: oklch(var(--b1) / 0.2) !important;
+      color: oklch(var(--bc)) !important;
     }
     .pip-challenge {
-      background: oklch(${bgColor} / 0.5) !important;
-      border: 1px solid oklch(${textColor} / 0.1) !important;
+      background: oklch(var(--b1) / 0.5) !important;
+      border: 1px solid oklch(var(--bc) / 0.1) !important;
     }
     .pip-challenge-header {
-      color: oklch(${primaryColor}) !important;
+      color: oklch(var(--p)) !important;
     }
     .pip-challenge-text {
-      color: oklch(${textColor} / 0.7) !important;
+      color: oklch(var(--bc) / 0.7) !important;
     }
   `
 }

--- a/components/atoms/SpotifyPlayer.vue
+++ b/components/atoms/SpotifyPlayer.vue
@@ -6,7 +6,7 @@
         <svg class="w-4 h-4 text-success" fill="currentColor" viewBox="0 0 24 24">
           <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
         </svg>
-        <h3 class="font-semibold text-sm">Spotify Player</h3>
+        <h3 class="font-semibold text-sm">{{ $t('spotify.player') }}</h3>
       </div>
 
       <!-- Input -->
@@ -14,19 +14,19 @@
         <input
           v-model="inputUrl"
           type="url"
-          placeholder="Link da playlist..."
+          :placeholder="$t('spotify.playlistLink')"
           class="input input-bordered input-sm flex-1"
           @keyup.enter="saveUrl"
         />
         <button class="btn btn-sm btn-primary" @click="saveUrl" :disabled="!inputUrl.trim()">
-          Usar
+          {{ $t('spotify.use') }}
         </button>
       </div>
 
       <!-- Status da playlist -->
       <div v-if="savedUrl" class="flex items-center justify-between text-xs">
-        <span class="text-success">Playlist ativa</span>
-        <button class="link link-error" @click="clearUrl">Remover</button>
+        <span class="text-success">{{ $t('spotify.activePlaylist') }}</span>
+        <button class="link link-error" @click="clearUrl">{{ $t('spotify.remove') }}</button>
       </div>
 
       <!-- Aviso de login -->
@@ -34,7 +34,7 @@
         <svg class="w-3.5 h-3.5 flex-shrink-0 text-info" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
-        <span>Para ouvir as musicas completas, faca login na sua conta do Spotify no navegador</span>
+        <span>{{ $t('spotify.loginInfo') }}</span>
       </div>
 
       <!-- Embed ou Placeholder -->
@@ -57,7 +57,7 @@
             <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
           </svg>
           <p class="text-base-content/40 text-sm">
-            Cole um link do Spotify
+            {{ $t('spotify.pasteLink') }}
           </p>
         </div>
       </div>

--- a/components/atoms/StartCycle.vue
+++ b/components/atoms/StartCycle.vue
@@ -5,8 +5,8 @@
         <svg class="w-20 h-20 mx-auto text-primary opacity-50 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M13 10V3L4 14h7v7l9-11h-7z" />
         </svg>
-        <h2 class="text-xl font-semibold mb-2">Start a new cycle to receive new challenges</h2>
-        <p class="text-base-content/60">Increase your level by completing challenges</p>
+        <h2 class="text-xl font-semibold mb-2">{{ $t('challenges.startCycle') }}</h2>
+        <p class="text-base-content/60">{{ $t('challenges.levelUp') }}</p>
       </div>
     </div>
   </div>

--- a/components/atoms/ThemeSelector.vue
+++ b/components/atoms/ThemeSelector.vue
@@ -12,20 +12,20 @@
         <button
           v-for="t in themes"
           :key="t"
-          class="w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-all duration-200"
+          class="w-full flex items-baseline gap-3 px-3 py-2 rounded-lg transition-all duration-200"
           :class="theme.currentTheme === t
             ? 'bg-primary/10 ring-1 ring-primary/30'
             : 'hover:bg-base-200'"
           @click="theme.setTheme(t)"
         >
           <span
-            class="w-6 h-6 rounded-full shrink-0 shadow-sm ring-1 ring-base-300 transition-transform duration-200"
+            class="w-6 h-6 rounded-full shrink-0 self-center shadow-sm ring-1 ring-base-300 transition-transform duration-200"
             :class="[previewColor(t), theme.currentTheme === t ? 'scale-110' : '']"
           />
           <span class="capitalize text-sm font-medium flex-1 text-left">{{ t }}</span>
           <svg
             v-if="theme.currentTheme === t"
-            class="w-4 h-4 text-primary"
+            class="w-4 h-4 text-primary self-center"
             fill="currentColor"
             viewBox="0 0 20 20"
           >

--- a/components/atoms/ThemeSelector.vue
+++ b/components/atoms/ThemeSelector.vue
@@ -5,7 +5,7 @@
         <svg class="w-5 h-5 text-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01" />
         </svg>
-        <h3 class="font-semibold text-sm">Tema</h3>
+        <h3 class="font-semibold text-sm">{{ $t('nav.theme') }}</h3>
       </div>
 
       <div class="space-y-1">

--- a/components/atoms/TimerPresets.vue
+++ b/components/atoms/TimerPresets.vue
@@ -24,9 +24,9 @@
 
       <!-- Custom input -->
       <div class="form-control">
-        <div class="flex gap-2 items-end">
-          <div class="flex-1">
-            <label class="label pb-1">
+        <div class="grid grid-cols-[1fr_auto] gap-2 items-end">
+          <div>
+            <label class="label py-1">
               <span class="label-text text-xs">{{ $t('timer.customTime') }}</span>
             </label>
             <input
@@ -41,7 +41,7 @@
             />
           </div>
           <button
-            class="btn btn-sm btn-outline"
+            class="btn btn-sm btn-outline self-end"
             @click="applyCustom"
             :disabled="countdown.isActive || !customInput || customInput < 1"
           >

--- a/components/atoms/TimerPresets.vue
+++ b/components/atoms/TimerPresets.vue
@@ -5,7 +5,7 @@
         <svg class="w-5 h-5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
-        <h3 class="font-semibold text-sm">Tempo do Pomodoro</h3>
+        <h3 class="font-semibold text-sm">{{ $t('timer.pomodoroTime') }}</h3>
       </div>
 
       <!-- Preset buttons -->
@@ -18,7 +18,7 @@
           @click="selectPreset(preset)"
           :disabled="countdown.isActive"
         >
-          {{ preset }}min
+          {{ $t('timer.minutes', { minutes: preset }) }}
         </button>
       </div>
 
@@ -27,7 +27,7 @@
         <div class="flex gap-2 items-end">
           <div class="flex-1">
             <label class="label pb-1">
-              <span class="label-text text-xs">Tempo personalizado (minutos)</span>
+              <span class="label-text text-xs">{{ $t('timer.customTime') }}</span>
             </label>
             <input
               v-model.number="customInput"
@@ -45,7 +45,7 @@
             @click="applyCustom"
             :disabled="countdown.isActive || !customInput || customInput < 1"
           >
-            Aplicar
+            {{ $t('timer.apply') }}
           </button>
         </div>
       </div>
@@ -60,7 +60,7 @@
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
         </svg>
-        Resetar Timer
+        {{ $t('timer.resetTimer') }}
       </button>
     </div>
   </div>

--- a/components/molecules/Challenge.vue
+++ b/components/molecules/Challenge.vue
@@ -18,8 +18,8 @@
       <p class="text-base-content/70 text-sm leading-relaxed">{{ description }}</p>
 
       <div class="card-actions w-full mt-4 grid grid-cols-2 gap-2">
-        <button class="btn btn-error btn-outline btn-sm h-10" @click="resetChallenges">Falhou</button>
-        <button class="btn btn-success btn-sm h-10" @click="challengeSucceeded">Completou</button>
+        <button class="btn btn-error btn-outline btn-sm h-10" @click="resetChallenges">{{ $t('challenges.failed') }}</button>
+        <button class="btn btn-success btn-sm h-10" @click="challengeSucceeded">{{ $t('challenges.completed') }}</button>
       </div>
     </div>
   </div>
@@ -30,21 +30,12 @@ import { computed } from 'vue'
 import { useChallengesStore } from '~/stores/challenges'
 import { useCountdownStore } from '~/stores/countdown'
 
+const { t } = useI18n()
 const props = defineProps<{ type: string; description: string; amount: number }>()
 const challenges = useChallengesStore()
 const countdown = useCountdownStore()
 
-const typeLabels: Record<string, string> = {
-  body: 'Alongamento',
-  eye: 'Exercicio Ocular',
-  drink: 'Hidratacao',
-  breathe: 'Respiracao',
-  posture: 'Postura',
-  meditate: 'Meditacao Rapida',
-  walk: 'Caminhada',
-}
-
-const typeLabel = computed(() => typeLabels[props.type] || 'Desafio')
+const typeLabel = computed(() => t(`challengeTypes.${props.type}`))
 
 const typeBg = computed(() => {
   const map: Record<string, string> = {

--- a/components/molecules/Profile.vue
+++ b/components/molecules/Profile.vue
@@ -30,7 +30,7 @@
 
         <!-- GitHub Login -->
         <div class="form-control">
-          <label class="label py-1 items-center">
+          <label class="label py-1 items-baseline">
             <span class="label-text font-medium">{{ $t('profile.githubUsername') }}</span>
           </label>
           <div class="grid grid-cols-[1fr_auto] gap-2">
@@ -48,7 +48,7 @@
               {{ $t('profile.save') }}
             </button>
           </div>
-          <label class="label py-1 items-center" v-if="profile.profile.githubUsername">
+          <label class="label py-1 items-baseline" v-if="profile.profile.githubUsername">
             <span class="label-text-alt text-success truncate">{{ $t('profile.connectedAs', { username: profile.profile.githubUsername }) }}</span>
             <button class="label-text-alt link link-error shrink-0" @click="clearGithub">{{ $t('profile.remove') }}</button>
           </label>
@@ -58,7 +58,7 @@
 
         <!-- Manual Name -->
         <div class="form-control">
-          <label class="label py-1 items-center">
+          <label class="label py-1 items-baseline">
             <span class="label-text font-medium">{{ $t('profile.name') }}</span>
           </label>
           <input
@@ -71,7 +71,7 @@
 
         <!-- Manual Avatar URL -->
         <div class="form-control">
-          <label class="label py-1 items-center">
+          <label class="label py-1 items-baseline">
             <span class="label-text font-medium">{{ $t('profile.photoUrl') }}</span>
           </label>
           <input
@@ -81,14 +81,14 @@
             class="input input-bordered input-sm w-full"
             :disabled="!!profile.profile.githubUsername"
           />
-          <label class="label py-1 items-center">
+          <label class="label py-1 items-baseline">
             <span class="label-text-alt">{{ $t('profile.pasteLink') }}</span>
           </label>
         </div>
 
         <!-- Preview -->
-        <div class="flex items-center gap-3 p-3 bg-base-200 rounded-lg overflow-hidden">
-          <div class="avatar shrink-0">
+        <div class="flex items-baseline gap-3 p-3 bg-base-200 rounded-lg overflow-hidden">
+          <div class="avatar shrink-0 self-center">
             <div class="w-12 rounded-full">
               <img :src="previewAvatar" :alt="nameInput" />
             </div>

--- a/components/molecules/Profile.vue
+++ b/components/molecules/Profile.vue
@@ -30,15 +30,15 @@
 
         <!-- GitHub Login -->
         <div class="form-control">
-          <label class="label py-1">
+          <label class="label py-1 items-center">
             <span class="label-text font-medium">{{ $t('profile.githubUsername') }}</span>
           </label>
-          <div class="flex gap-2">
+          <div class="grid grid-cols-[1fr_auto] gap-2">
             <input
               v-model="githubInput"
               type="text"
               :placeholder="$t('profile.githubPlaceholder')"
-              class="input input-bordered input-sm flex-1 min-w-0"
+              class="input input-bordered input-sm w-full min-w-0"
               @keyup.enter="saveGithub"
             />
             <button class="btn btn-sm btn-primary shrink-0" @click="saveGithub">
@@ -48,7 +48,7 @@
               {{ $t('profile.save') }}
             </button>
           </div>
-          <label class="label py-1" v-if="profile.profile.githubUsername">
+          <label class="label py-1 items-center" v-if="profile.profile.githubUsername">
             <span class="label-text-alt text-success truncate">{{ $t('profile.connectedAs', { username: profile.profile.githubUsername }) }}</span>
             <button class="label-text-alt link link-error shrink-0" @click="clearGithub">{{ $t('profile.remove') }}</button>
           </label>
@@ -58,7 +58,7 @@
 
         <!-- Manual Name -->
         <div class="form-control">
-          <label class="label py-1">
+          <label class="label py-1 items-center">
             <span class="label-text font-medium">{{ $t('profile.name') }}</span>
           </label>
           <input
@@ -71,7 +71,7 @@
 
         <!-- Manual Avatar URL -->
         <div class="form-control">
-          <label class="label py-1">
+          <label class="label py-1 items-center">
             <span class="label-text font-medium">{{ $t('profile.photoUrl') }}</span>
           </label>
           <input
@@ -81,7 +81,7 @@
             class="input input-bordered input-sm w-full"
             :disabled="!!profile.profile.githubUsername"
           />
-          <label class="label py-1">
+          <label class="label py-1 items-center">
             <span class="label-text-alt">{{ $t('profile.pasteLink') }}</span>
           </label>
         </div>

--- a/components/molecules/Profile.vue
+++ b/components/molecules/Profile.vue
@@ -37,7 +37,7 @@
             <input
               v-model="githubInput"
               type="text"
-              placeholder="ex: Azincourt-tech"
+              :placeholder="$t('profile.githubPlaceholder')"
               class="input input-bordered input-sm flex-1"
               @keyup.enter="saveGithub"
             />
@@ -64,7 +64,7 @@
           <input
             v-model="nameInput"
             type="text"
-            placeholder="Seu nome"
+            :placeholder="$t('profile.namePlaceholder')"
             class="input input-bordered input-sm"
           />
         </div>
@@ -94,7 +94,7 @@
             </div>
           </div>
           <div>
-            <p class="font-medium text-sm">{{ nameInput || 'User' }}</p>
+            <p class="font-medium text-sm">{{ nameInput || $t('profile.defaultName') }}</p>
             <p class="text-xs text-base-content/60">{{ $t('profile.preview') }}</p>
           </div>
         </div>
@@ -114,6 +114,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useProfileStore } from '~/stores/profile'
 import { useChallengesStore } from '~/stores/challenges'
 
+const { t } = useI18n()
 const profile = useProfileStore()
 const challenges = useChallengesStore()
 
@@ -150,7 +151,7 @@ function clearGithub() {
 
 function save() {
   profile.updateProfile({
-    name: nameInput.value || 'User',
+    name: nameInput.value || t('profile.defaultName'),
     avatar: profile.profile.githubUsername ? '' : avatarInput.value,
   })
   profile.setEditing(false)

--- a/components/molecules/Profile.vue
+++ b/components/molecules/Profile.vue
@@ -14,10 +14,10 @@
             <svg class="w-4 h-4 text-warning" fill="currentColor" viewBox="0 0 20 20">
               <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
             </svg>
-            <span class="badge badge-warning badge-sm font-semibold">Level {{ challenges.level }}</span>
+            <span class="badge badge-warning badge-sm font-semibold">{{ $t('nav.level', { level: challenges.level }) }}</span>
           </div>
         </div>
-        <button class="btn btn-ghost btn-sm btn-circle" @click="profile.setEditing(true)" title="Editar perfil">
+        <button class="btn btn-ghost btn-sm btn-circle" @click="profile.setEditing(true)" :title="$t('profile.edit')">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
           </svg>
@@ -26,12 +26,12 @@
 
       <!-- Edit Mode -->
       <div v-else class="space-y-4">
-        <h3 class="font-bold text-lg">Editar Perfil</h3>
+        <h3 class="font-bold text-lg">{{ $t('profile.editProfile') }}</h3>
 
         <!-- GitHub Login -->
         <div class="form-control">
           <label class="label">
-            <span class="label-text font-medium">Username do GitHub</span>
+            <span class="label-text font-medium">{{ $t('profile.githubUsername') }}</span>
           </label>
           <div class="flex gap-2">
             <input
@@ -45,21 +45,21 @@
               <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
               </svg>
-              Usar
+              {{ $t('profile.save') }}
             </button>
           </div>
           <label class="label" v-if="profile.profile.githubUsername">
-            <span class="label-text-alt text-success">Conectado como {{ profile.profile.githubUsername }}</span>
-            <button class="label-text-alt link link-error" @click="clearGithub">Remover</button>
+            <span class="label-text-alt text-success">{{ $t('profile.connectedAs', { username: profile.profile.githubUsername }) }}</span>
+            <button class="label-text-alt link link-error" @click="clearGithub">{{ $t('profile.remove') }}</button>
           </label>
         </div>
 
-        <div class="divider text-xs">ou</div>
+        <div class="divider text-xs">{{ $t('profile.or') }}</div>
 
         <!-- Manual Name -->
         <div class="form-control">
           <label class="label">
-            <span class="label-text font-medium">Nome</span>
+            <span class="label-text font-medium">{{ $t('profile.name') }}</span>
           </label>
           <input
             v-model="nameInput"
@@ -72,7 +72,7 @@
         <!-- Manual Avatar URL -->
         <div class="form-control">
           <label class="label">
-            <span class="label-text font-medium">URL da foto</span>
+            <span class="label-text font-medium">{{ $t('profile.photoUrl') }}</span>
           </label>
           <input
             v-model="avatarInput"
@@ -82,7 +82,7 @@
             :disabled="!!profile.profile.githubUsername"
           />
           <label class="label">
-            <span class="label-text-alt">Cole o link de uma imagem</span>
+            <span class="label-text-alt">{{ $t('profile.pasteLink') }}</span>
           </label>
         </div>
 
@@ -95,14 +95,14 @@
           </div>
           <div>
             <p class="font-medium text-sm">{{ nameInput || 'User' }}</p>
-            <p class="text-xs text-base-content/60">Preview</p>
+            <p class="text-xs text-base-content/60">{{ $t('profile.preview') }}</p>
           </div>
         </div>
 
         <!-- Actions -->
         <div class="flex gap-2">
-          <button class="btn btn-primary btn-sm flex-1" @click="save">Salvar</button>
-          <button class="btn btn-ghost btn-sm" @click="profile.setEditing(false)">Cancelar</button>
+          <button class="btn btn-primary btn-sm flex-1" @click="save">{{ $t('profile.save') }}</button>
+          <button class="btn btn-ghost btn-sm" @click="profile.setEditing(false)">{{ $t('profile.cancel') }}</button>
         </div>
       </div>
     </div>

--- a/components/molecules/Profile.vue
+++ b/components/molecules/Profile.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="card bg-base-100 shadow-sm">
-    <div class="card-body p-4">
+  <div class="card bg-base-100 shadow-sm overflow-hidden">
+    <div class="card-body p-4 min-w-0">
       <!-- Display Mode -->
       <div v-if="!profile.isEditing" class="flex items-center gap-4">
         <div class="avatar">
@@ -25,12 +25,12 @@
       </div>
 
       <!-- Edit Mode -->
-      <div v-else class="space-y-4">
+      <div v-else class="space-y-3">
         <h3 class="font-bold text-lg">{{ $t('profile.editProfile') }}</h3>
 
         <!-- GitHub Login -->
         <div class="form-control">
-          <label class="label">
+          <label class="label py-1">
             <span class="label-text font-medium">{{ $t('profile.githubUsername') }}</span>
           </label>
           <div class="flex gap-2">
@@ -38,63 +38,63 @@
               v-model="githubInput"
               type="text"
               :placeholder="$t('profile.githubPlaceholder')"
-              class="input input-bordered input-sm flex-1"
+              class="input input-bordered input-sm flex-1 min-w-0"
               @keyup.enter="saveGithub"
             />
-            <button class="btn btn-sm btn-primary" @click="saveGithub">
+            <button class="btn btn-sm btn-primary shrink-0" @click="saveGithub">
               <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
               </svg>
               {{ $t('profile.save') }}
             </button>
           </div>
-          <label class="label" v-if="profile.profile.githubUsername">
-            <span class="label-text-alt text-success">{{ $t('profile.connectedAs', { username: profile.profile.githubUsername }) }}</span>
-            <button class="label-text-alt link link-error" @click="clearGithub">{{ $t('profile.remove') }}</button>
+          <label class="label py-1" v-if="profile.profile.githubUsername">
+            <span class="label-text-alt text-success truncate">{{ $t('profile.connectedAs', { username: profile.profile.githubUsername }) }}</span>
+            <button class="label-text-alt link link-error shrink-0" @click="clearGithub">{{ $t('profile.remove') }}</button>
           </label>
         </div>
 
-        <div class="divider text-xs">{{ $t('profile.or') }}</div>
+        <div class="divider text-xs my-2">{{ $t('profile.or') }}</div>
 
         <!-- Manual Name -->
         <div class="form-control">
-          <label class="label">
+          <label class="label py-1">
             <span class="label-text font-medium">{{ $t('profile.name') }}</span>
           </label>
           <input
             v-model="nameInput"
             type="text"
             :placeholder="$t('profile.namePlaceholder')"
-            class="input input-bordered input-sm"
+            class="input input-bordered input-sm w-full"
           />
         </div>
 
         <!-- Manual Avatar URL -->
         <div class="form-control">
-          <label class="label">
+          <label class="label py-1">
             <span class="label-text font-medium">{{ $t('profile.photoUrl') }}</span>
           </label>
           <input
             v-model="avatarInput"
             type="url"
             placeholder="https://..."
-            class="input input-bordered input-sm"
+            class="input input-bordered input-sm w-full"
             :disabled="!!profile.profile.githubUsername"
           />
-          <label class="label">
+          <label class="label py-1">
             <span class="label-text-alt">{{ $t('profile.pasteLink') }}</span>
           </label>
         </div>
 
         <!-- Preview -->
-        <div class="flex items-center gap-3 p-3 bg-base-200 rounded-lg">
-          <div class="avatar">
+        <div class="flex items-center gap-3 p-3 bg-base-200 rounded-lg overflow-hidden">
+          <div class="avatar shrink-0">
             <div class="w-12 rounded-full">
               <img :src="previewAvatar" :alt="nameInput" />
             </div>
           </div>
-          <div>
-            <p class="font-medium text-sm">{{ nameInput || $t('profile.defaultName') }}</p>
+          <div class="min-w-0">
+            <p class="font-medium text-sm truncate">{{ nameInput || $t('profile.defaultName') }}</p>
             <p class="text-xs text-base-content/60">{{ $t('profile.preview') }}</p>
           </div>
         </div>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "title": "Pomodoro Move.it",
+    "description": "Pomodoro timer with health and wellness challenges"
+  },
+  "nav": {
+    "level": "Level {level}",
+    "theme": "Theme",
+    "language": "Language"
+  },
+  "timer": {
+    "startCycle": "Start cycle",
+    "abandonCycle": "Abandon cycle",
+    "cycleCompleted": "Cycle completed",
+    "pomodoroTime": "Pomodoro Time",
+    "customTime": "Custom time (minutes)",
+    "apply": "Apply",
+    "resetTimer": "Reset Timer",
+    "minutes": "{minutes}min"
+  },
+  "profile": {
+    "editProfile": "Edit Profile",
+    "githubUsername": "GitHub Username",
+    "connectedAs": "Connected as {username}",
+    "remove": "Remove",
+    "or": "or",
+    "name": "Name",
+    "photoUrl": "Photo URL",
+    "pasteLink": "Paste an image link",
+    "preview": "Preview",
+    "save": "Save",
+    "cancel": "Cancel",
+    "edit": "Edit profile"
+  },
+  "challenges": {
+    "completedChallenges": "Completed challenges",
+    "allChallenges": "All Challenges",
+    "available": "{count} available",
+    "challenges": "challenges",
+    "failed": "Failed",
+    "completed": "Completed",
+    "startCycle": "Start a new cycle to receive new challenges",
+    "levelUp": "Increase your level by completing challenges"
+  },
+  "challengeTypes": {
+    "body": "Stretching",
+    "eye": "Eye Exercise",
+    "drink": "Hydration",
+    "breathe": "Breathing",
+    "posture": "Posture",
+    "meditate": "Quick Meditation",
+    "walk": "Walking"
+  },
+  "levelUp": {
+    "congratulations": "Congratulations!",
+    "newLevel": "You reached a new level!",
+    "continue": "Continue"
+  },
+  "pip": {
+    "closeWindow": "Close floating window",
+    "openWindow": "Open floating window",
+    "inProgress": "In progress",
+    "paused": "Paused",
+    "stop": "Stop",
+    "start": "Start",
+    "reset": "Reset",
+    "challenge": "Challenge",
+    "startForChallenges": "Start a cycle to receive challenges",
+    "allowPopups": "Allow popups to use the floating window"
+  },
+  "spotify": {
+    "player": "Spotify Player",
+    "playlistLink": "Playlist link...",
+    "use": "Use",
+    "activePlaylist": "Active playlist",
+    "remove": "Remove",
+    "loginInfo": "To listen to full songs, log in to your Spotify account in the browser",
+    "pasteLink": "Paste a Spotify link"
+  },
+  "experience": {
+    "xp": "xp"
+  },
+  "footer": {
+    "madeBy": "Made by"
+  },
+  "notifications": {
+    "cycleCompleted": "Cycle completed!",
+    "newChallenge": "New challenge available!"
+  }
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -21,16 +21,19 @@
   "profile": {
     "editProfile": "Edit Profile",
     "githubUsername": "GitHub Username",
+    "githubPlaceholder": "e.g.: Azincourt-tech",
     "connectedAs": "Connected as {username}",
     "remove": "Remove",
     "or": "or",
     "name": "Name",
+    "namePlaceholder": "Your name",
     "photoUrl": "Photo URL",
     "pasteLink": "Paste an image link",
     "preview": "Preview",
     "save": "Save",
     "cancel": "Cancel",
-    "edit": "Edit profile"
+    "edit": "Edit profile",
+    "defaultName": "User"
   },
   "challenges": {
     "completedChallenges": "Completed challenges",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -1,0 +1,90 @@
+{
+  "app": {
+    "title": "Pomodoro Move.it",
+    "description": "Pomodoro timer com desafios de saude e bem-estar"
+  },
+  "nav": {
+    "level": "Level {level}",
+    "theme": "Tema",
+    "language": "Idioma"
+  },
+  "timer": {
+    "startCycle": "Iniciar ciclo",
+    "abandonCycle": "Abandonar ciclo",
+    "cycleCompleted": "Ciclo completado",
+    "pomodoroTime": "Tempo do Pomodoro",
+    "customTime": "Tempo personalizado (minutos)",
+    "apply": "Aplicar",
+    "resetTimer": "Resetar Timer",
+    "minutes": "{minutes}min"
+  },
+  "profile": {
+    "editProfile": "Editar Perfil",
+    "githubUsername": "Username do GitHub",
+    "connectedAs": "Conectado como {username}",
+    "remove": "Remover",
+    "or": "ou",
+    "name": "Nome",
+    "photoUrl": "URL da foto",
+    "pasteLink": "Cole o link de uma imagem",
+    "preview": "Preview",
+    "save": "Salvar",
+    "cancel": "Cancelar",
+    "edit": "Editar perfil"
+  },
+  "challenges": {
+    "completedChallenges": "Desafios completados",
+    "allChallenges": "Todos os Challenges",
+    "available": "{count} disponiveis",
+    "challenges": "challenges",
+    "failed": "Falhou",
+    "completed": "Completou",
+    "startCycle": "Inicie um ciclo para receber novos desafios",
+    "levelUp": "Aumente seu nivel completando os desafios"
+  },
+  "challengeTypes": {
+    "body": "Alongamento",
+    "eye": "Exercicio Ocular",
+    "drink": "Hidratacao",
+    "breathe": "Respiracao",
+    "posture": "Postura",
+    "meditate": "Meditacao Rapida",
+    "walk": "Caminhada"
+  },
+  "levelUp": {
+    "congratulations": "Parabens!",
+    "newLevel": "Voce alcancou um novo nivel!",
+    "continue": "Continuar"
+  },
+  "pip": {
+    "closeWindow": "Fechar janela flutuante",
+    "openWindow": "Abrir janela flutuante",
+    "inProgress": "Em andamento",
+    "paused": "Pausado",
+    "stop": "Parar",
+    "start": "Iniciar",
+    "reset": "Reset",
+    "challenge": "Desafio",
+    "startForChallenges": "Inicie um ciclo para receber desafios",
+    "allowPopups": "Permita popups para usar a janela flutuante"
+  },
+  "spotify": {
+    "player": "Spotify Player",
+    "playlistLink": "Link da playlist...",
+    "use": "Usar",
+    "activePlaylist": "Playlist ativa",
+    "remove": "Remover",
+    "loginInfo": "Para ouvir as musicas completas, faca login na sua conta do Spotify no navegador",
+    "pasteLink": "Cole um link do Spotify"
+  },
+  "experience": {
+    "xp": "xp"
+  },
+  "footer": {
+    "madeBy": "Feito por"
+  },
+  "notifications": {
+    "cycleCompleted": "Ciclo completado!",
+    "newChallenge": "Novo desafio disponivel!"
+  }
+}

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -21,16 +21,19 @@
   "profile": {
     "editProfile": "Editar Perfil",
     "githubUsername": "Username do GitHub",
+    "githubPlaceholder": "ex: Azincourt-tech",
     "connectedAs": "Conectado como {username}",
     "remove": "Remover",
     "or": "ou",
     "name": "Nome",
+    "namePlaceholder": "Seu nome",
     "photoUrl": "URL da foto",
     "pasteLink": "Cole o link de uma imagem",
     "preview": "Preview",
     "save": "Salvar",
     "cancel": "Cancelar",
-    "edit": "Editar perfil"
+    "edit": "Editar perfil",
+    "defaultName": "Usuario"
   },
   "challenges": {
     "completedChallenges": "Desafios completados",

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -90,7 +90,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import ExperienceBar from '~/components/atoms/ExperienceBar.vue'
 import ThemeSelector from '~/components/atoms/ThemeSelector.vue'
 import LanguageSelector from '~/components/atoms/LanguageSelector.vue'
@@ -101,6 +101,11 @@ const { locale } = useI18n()
 const challenges = useChallengesStore()
 const theme = useThemeStore()
 const currentLocale = ref(locale.value)
+
+// Sync navbar locale display with i18n changes
+watch(locale, (newLocale) => {
+  currentLocale.value = newLocale
+})
 
 const colorMap: Record<string, string> = {
   light: 'bg-gray-100 border border-gray-300',

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -24,7 +24,7 @@
 
           <!-- Language selector -->
           <div class="dropdown dropdown-end">
-            <div tabindex="0" role="button" class="btn btn-ghost btn-sm gap-2" :title="$t('nav.language')">
+            <div tabindex="0" role="button" class="btn btn-ghost btn-sm gap-2 items-baseline" :title="$t('nav.language')">
               <span class="text-lg">{{ currentLocale === 'pt-BR' ? '🇧🇷' : '🇺🇸' }}</span>
               <span class="hidden sm:inline text-xs font-medium">{{ currentLocale === 'pt-BR' ? 'PT' : 'EN' }}</span>
               <svg class="w-3 h-3 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -19,12 +19,26 @@
             <svg class="w-4 h-4 text-warning" fill="currentColor" viewBox="0 0 20 20">
               <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
             </svg>
-            <span class="text-sm font-semibold">Level {{ challenges.level }}</span>
+            <span class="text-sm font-semibold">{{ $t('nav.level', { level: challenges.level }) }}</span>
+          </div>
+
+          <!-- Language selector -->
+          <div class="dropdown dropdown-end">
+            <div tabindex="0" role="button" class="btn btn-ghost btn-sm gap-2" :title="$t('nav.language')">
+              <span class="text-lg">{{ currentLocale === 'pt-BR' ? '🇧🇷' : '🇺🇸' }}</span>
+              <span class="hidden sm:inline text-xs font-medium">{{ currentLocale === 'pt-BR' ? 'PT' : 'EN' }}</span>
+              <svg class="w-3 h-3 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+              </svg>
+            </div>
+            <div tabindex="0" class="dropdown-content z-[10] mt-3 p-2 shadow-xl bg-base-100 rounded-box w-64 border border-base-300/50">
+              <LanguageSelector />
+            </div>
           </div>
 
           <!-- Theme toggle - clearly visible -->
           <div class="dropdown dropdown-end">
-            <div tabindex="0" role="button" class="btn btn-ghost btn-sm gap-2" title="Mudar tema">
+            <div tabindex="0" role="button" class="btn btn-ghost btn-sm gap-2" :title="$t('nav.theme')">
               <span class="w-5 h-5 rounded-full shadow-sm ring-1 ring-base-300" :class="themePreviewColor" />
               <span class="hidden sm:inline text-xs font-medium capitalize">{{ theme.currentTheme }}</span>
               <svg class="w-3 h-3 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -57,10 +71,10 @@
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
-            <span>Pomodoro Move.it</span>
+            <span>{{ $t('app.title') }}</span>
           </div>
           <div class="flex items-center gap-4 text-base-content/40">
-            <span>Feito por</span>
+            <span>{{ $t('footer.madeBy') }}</span>
             <a href="https://github.com/Azincourt-tech" target="_blank" rel="noopener" class="link link-hover text-primary font-medium">
               Willian
             </a>
@@ -76,14 +90,17 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import ExperienceBar from '~/components/atoms/ExperienceBar.vue'
 import ThemeSelector from '~/components/atoms/ThemeSelector.vue'
+import LanguageSelector from '~/components/atoms/LanguageSelector.vue'
 import { useChallengesStore } from '~/stores/challenges'
 import { useThemeStore } from '~/stores/theme'
 
+const { locale } = useI18n()
 const challenges = useChallengesStore()
 const theme = useThemeStore()
+const currentLocale = ref(locale.value)
 
 const colorMap: Record<string, string> = {
   light: 'bg-gray-100 border border-gray-300',
@@ -99,4 +116,13 @@ const colorMap: Record<string, string> = {
 }
 
 const themePreviewColor = computed(() => colorMap[theme.currentTheme] || 'bg-gray-400')
+
+onMounted(() => {
+  if (import.meta.client) {
+    const saved = localStorage.getItem('pomodoro-locale')
+    if (saved && (saved === 'pt-BR' || saved === 'en')) {
+      currentLocale.value = saved
+    }
+  }
+})
 </script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -6,7 +6,23 @@ export default defineNuxtConfig({
   modules: [
     '@nuxtjs/tailwindcss',
     '@pinia/nuxt',
+    '@nuxtjs/i18n',
   ],
+
+  i18n: {
+    locales: [
+      { code: 'pt-BR', name: 'Portugues', file: 'pt-BR.json' },
+      { code: 'en', name: 'English', file: 'en.json' },
+    ],
+    defaultLocale: 'pt-BR',
+    lazy: true,
+    langDir: './',
+    strategy: 'no_prefix',
+    detectBrowserLanguage: {
+      useCookie: false,
+      fallbackLocale: 'pt-BR',
+    },
+  },
 
   app: {
     head: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10116,7 +10116,6 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -13650,7 +13649,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.31.tgz",
       "integrity": "sha512-iV/sU9SzOlmA/0tygSmjkEN6Jbs3nPoIPFhCMLD2STrjgOU8DX7ZtzMhg4ahVwf5Rp9KoFzcXeB1ZrVbLBp5/Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.31",
         "@vue/compiler-sfc": "3.5.31",
@@ -13943,7 +13941,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pomodoro-nuxt",
       "version": "2.0.0",
       "dependencies": {
+        "@nuxtjs/i18n": "^9.5.6",
         "@pinia/nuxt": "^0.9.0",
         "nuxt": "^3.15.0",
         "pinia": "^2.3.0",
@@ -61,6 +62,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -582,36 +584,12 @@
       "integrity": "sha512-/B8YJGPzaYq1NbsQmwgP8EZqg40NpTw4ZB3suuI0TplbxKHeK94jeaawLmVhCv+YwUnOpiWEz9U6SeThku/8JQ==",
       "license": "MIT"
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
       "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1032,6 +1010,391 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
+      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
+      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@intlify/bundle-utils": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@intlify/bundle-utils/-/bundle-utils-10.0.1.tgz",
+      "integrity": "sha512-WkaXfSevtpgtUR4t8K2M6lbR7g03mtOxFeh+vXp5KExvPqS12ppaRj1QxzwRuRI5VUto54A22BjKoBMLyHILWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/message-compiler": "^11.1.2",
+        "@intlify/shared": "^11.1.2",
+        "acorn": "^8.8.2",
+        "escodegen": "^2.1.0",
+        "estree-walker": "^2.0.2",
+        "jsonc-eslint-parser": "^2.3.0",
+        "mlly": "^1.2.0",
+        "source-map-js": "^1.0.1",
+        "yaml-eslint-parser": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependenciesMeta": {
+        "petite-vue-i18n": {
+          "optional": true
+        },
+        "vue-i18n": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@intlify/bundle-utils/node_modules/@intlify/message-compiler": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.3.0.tgz",
+      "integrity": "sha512-RAJp3TMsqohg/Wa7bVF3cChRhecSYBLrTCQSj7j0UtWVFLP+6iEJoE2zb7GU5fp+fmG5kCbUdzhmlAUCWXiUJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "11.3.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/bundle-utils/node_modules/@intlify/shared": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.3.0.tgz",
+      "integrity": "sha512-LC6P/uay7rXL5zZ5+5iRJfLs/iUN8apu9tm8YqQVmW3Uq3X4A0dOFUIDuAmB7gAC29wTHOS3EiN/IosNSz0eNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/core": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@intlify/core/-/core-10.0.8.tgz",
+      "integrity": "sha512-2BbgN0aeuYHOHe7kVlTr2XxyrnLQZ/4/Y0Pw8luU67723+AqVYqxB7ZG1FzLCVNwAmzdVZMjKzFpgOzdUSdBfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "10.0.8",
+        "@intlify/shared": "10.0.8"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/core-base": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-10.0.8.tgz",
+      "integrity": "sha512-FoHslNWSoHjdUBLy35bpm9PV/0LVI/DSv9L6Km6J2ad8r/mm0VaGg06C40FqlE8u2ADcGUM60lyoU7Myo4WNZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/message-compiler": "10.0.8",
+        "@intlify/shared": "10.0.8"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/h3": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@intlify/h3/-/h3-0.6.1.tgz",
+      "integrity": "sha512-hFMcqWXCoFNZkraa+JF7wzByGdE0vGi8rUs7CTFrE4hE3X2u9QcelH8VRO8mPgJDH+TgatzvrVp6iZsWVluk2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core": "^10.0.3",
+        "@intlify/utils": "^0.13.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-10.0.8.tgz",
+      "integrity": "sha512-DV+sYXIkHVd5yVb2mL7br/NEUwzUoLBsMkV3H0InefWgmYa34NLZUvMCGi5oWX+Hqr2Y2qUxnVrnOWF4aBlgWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "10.0.8",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-10.0.8.tgz",
+      "integrity": "sha512-BcmHpb5bQyeVNrptC3UhzpBZB/YHHDoEREOUERrmF2BRxsyOEuRrq+Z96C/D4+2KJb8kuHiouzAei7BXlG0YYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/unplugin-vue-i18n": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@intlify/unplugin-vue-i18n/-/unplugin-vue-i18n-6.0.8.tgz",
+      "integrity": "sha512-Vvm3KhjE6TIBVUQAk37rBiaYy2M5OcWH0ZcI1XKEsOTeN1o0bErk+zeuXmcrcMc/73YggfI8RoxOUz9EB/69JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@intlify/bundle-utils": "^10.0.1",
+        "@intlify/shared": "^11.1.2",
+        "@intlify/vue-i18n-extensions": "^8.0.0",
+        "@rollup/pluginutils": "^5.1.0",
+        "@typescript-eslint/scope-manager": "^8.13.0",
+        "@typescript-eslint/typescript-estree": "^8.13.0",
+        "debug": "^4.3.3",
+        "fast-glob": "^3.2.12",
+        "js-yaml": "^4.1.0",
+        "json5": "^2.2.3",
+        "pathe": "^1.0.0",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2",
+        "unplugin": "^1.1.0",
+        "vue": "^3.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "petite-vue-i18n": "*",
+        "vue": "^3.2.25",
+        "vue-i18n": "*"
+      },
+      "peerDependenciesMeta": {
+        "petite-vue-i18n": {
+          "optional": true
+        },
+        "vue-i18n": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@intlify/unplugin-vue-i18n/node_modules/@intlify/shared": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.3.0.tgz",
+      "integrity": "sha512-LC6P/uay7rXL5zZ5+5iRJfLs/iUN8apu9tm8YqQVmW3Uq3X4A0dOFUIDuAmB7gAC29wTHOS3EiN/IosNSz0eNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/unplugin-vue-i18n/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "license": "MIT"
+    },
+    "node_modules/@intlify/unplugin-vue-i18n/node_modules/unplugin": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.16.1.tgz",
+      "integrity": "sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@intlify/utils": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@intlify/utils/-/utils-0.13.0.tgz",
+      "integrity": "sha512-8i3uRdAxCGzuHwfmHcVjeLQBtysQB2aXl/ojoagDut5/gY5lvWCQ2+cnl2TiqE/fXj/D8EhWG/SLKA7qz4a3QA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/vue-i18n-extensions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@intlify/vue-i18n-extensions/-/vue-i18n-extensions-8.0.0.tgz",
+      "integrity": "sha512-w0+70CvTmuqbskWfzeYhn0IXxllr6mU+IeM2MU0M+j9OW64jkrvqY+pYFWrUnIIC9bEdij3NICruicwd5EgUuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.24.6",
+        "@intlify/shared": "^10.0.0",
+        "@vue/compiler-dom": "^3.2.45",
+        "vue-i18n": "^10.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@intlify/shared": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@vue/compiler-dom": "^3.0.0",
+        "vue": "^3.0.0",
+        "vue-i18n": "^9.0.0 || ^10.0.0 || ^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@intlify/shared": {
+          "optional": true
+        },
+        "@vue/compiler-dom": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-i18n": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@ioredis/commands": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
@@ -1226,6 +1589,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@miyaneee/rollup-plugin-json5": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@miyaneee/rollup-plugin-json5/-/rollup-plugin-json5-1.2.0.tgz",
+      "integrity": "sha512-JjTIaXZp9WzhUHpElrqPnl1AzBi/rvRs065F71+aTmlqvTMVkdbjZ8vfFl4nRlgJy+TPBw69ZK4pwFdmOAt4aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0",
+        "json5": "^2.2.3"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1518,6 +1894,7 @@
       "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.2.tgz",
       "integrity": "sha512-Bd6m6mrDrqpBEbX+g0rc66/ALd1sxlgdx5nfK9MAYO0yKLTOSK7McSYz1KcOYn3LQFCXOWfvXwaqih/b+REI1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "c12": "^3.3.3",
         "consola": "^3.4.2",
@@ -1682,6 +2059,947 @@
         }
       }
     },
+    "node_modules/@nuxtjs/i18n": {
+      "version": "9.5.6",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/i18n/-/i18n-9.5.6.tgz",
+      "integrity": "sha512-PhrQtJT6Di9uoslL5BTrBFqntFlfCaUKlO3T9ORJwmWFdowPqQeFjQ9OjVbKA6TNWr3kQhDqLbIcGlhbuG1USQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/h3": "^0.6.1",
+        "@intlify/shared": "^10.0.7",
+        "@intlify/unplugin-vue-i18n": "^6.0.8",
+        "@intlify/utils": "^0.13.0",
+        "@miyaneee/rollup-plugin-json5": "^1.2.0",
+        "@nuxt/kit": "^3.17.2",
+        "@oxc-parser/wasm": "^0.60.0",
+        "@rollup/plugin-yaml": "^4.1.2",
+        "@vue/compiler-sfc": "^3.5.13",
+        "debug": "^4.4.0",
+        "defu": "^6.1.4",
+        "esbuild": "^0.25.1",
+        "estree-walker": "^3.0.3",
+        "h3": "^1.15.1",
+        "knitwork": "^1.2.0",
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "oxc-parser": "^0.70.0",
+        "pathe": "^2.0.3",
+        "typescript": "^5.6.2",
+        "ufo": "^1.5.4",
+        "unplugin": "^2.2.2",
+        "unplugin-vue-router": "^0.12.0",
+        "vue-i18n": "^10.0.7",
+        "vue-router": "^4.5.1"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/bobbiegoede"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.70.0.tgz",
+      "integrity": "sha512-pIi7L9PnsBctS/ruW6JQVSYRJkh76PblBN46uQxpBfVsM57c1s4HGZlmGysQWbdmQTFDZW+SmH3u0JpmDLF0+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.70.0.tgz",
+      "integrity": "sha512-EbKqtOHzZR56ZFC5HHg6XrYneFAJmpLC1Z6FSgbI061Ley1atAViQg7S6Agm9wAcPpns+BeFJqXEBx/y3MKa2w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.70.0.tgz",
+      "integrity": "sha512-MVUaOMEUVE8q3nsWtEo589h++V5wAdqTbCRa9WY4Yuyxska4xcuJQk/kDNCx+n92saS7Luk+b20O9+VCI03c+A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.70.0.tgz",
+      "integrity": "sha512-8N4JTYTgKiRHlMUDAdzKs6iEC57a8ex408VgKoLD/Fl+Un79qOti3S9sotdnWSdH/BsDQeO5NW+PKaqFBTw+hA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.70.0.tgz",
+      "integrity": "sha512-Bsu+YvtgWuSfSDJTHMF5APZBOtvddR0GiHyrL0yaXDwaYvAL/E7XcoSK2GdmKTpw+J8nk5IlejEXlQliPo52pQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.70.0.tgz",
+      "integrity": "sha512-tDzHWKexJPHR+qSiuAFoZ1v8EgCd4ggBNbjJHkcIHsoYKnsKaT1+uE9xfW9UhI1mhv2lo1JJ9n9og2yDTGxSeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.70.0.tgz",
+      "integrity": "sha512-BJ+N25UWmHU624558ojSTnht3uFL00jV1c8qk1hnKf4cl6+ovFcoktRWAWSBlgLEP8tLlu8qgIhz875tMj2PkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.70.0.tgz",
+      "integrity": "sha512-nxu22nVuPA2xy1cxvBC0D5mVl0myqStOw3XBkVkDViNL01iPyuEFJd5VsM0GqsgrXvF95H/jrbMd+XWnto924g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.70.0.tgz",
+      "integrity": "sha512-AQ6Xj97lYRxHZl94cZIHJxT5M1qkeEi+vQe+e7M2lAtjcURl8cwhZmWKSv4rt4BQRVfO3ys0bY8AgIh4eFJiqw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.70.0.tgz",
+      "integrity": "sha512-RIxaVsIxtG90CoX6/Okij8itaMrJp4SEJm1pSL0pz3hGo0yur3Il9M1mmGvOpW+avY8uHdwXIvf2qMnnTKZuoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.70.0.tgz",
+      "integrity": "sha512-B3S0G4TlZ+WLdQq4mSQtt2ZW0MAkKWc8dla17tZY86kcXvvCWwACvj7I27Z/nSlb7uJOdRZS9/r6Gw0uAARNVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.70.0.tgz",
+      "integrity": "sha512-QN8yxH7eHXTqed8Oo7ZUzOWn6hixXa8EVINLy21eLU9isoifSPKMswSmCXHxsM2L5rIIvzoaKfghGOru1mMQbw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.9"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.70.0.tgz",
+      "integrity": "sha512-6k8/s78g0GQKqrxk4F0wYj32NBF9oSP6089e6BeuIRQ9l+Zh0cuI6unJeLzXNszxmlqq84xmf/tmP3MSDG43Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.70.0.tgz",
+      "integrity": "sha512-nd9o1QtEvupaJZ3Wn7PfsuC00n31NNRQZ5+Mui6Q0ZyDzp+obqPUSbSt7xh9Dy0c5zgtYMk8WY4n/VBJY2VvTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/@oxc-project/types": {
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.70.0.tgz",
+      "integrity": "sha512-ngyLUpUjO3dpqygSRQDx7nMx8+BmXbWOU4oIwTJFV2MVIDG7knIZwgdwXlQWLg3C3oxg1lS7ppMtPKqKFb7wzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/ast-kit": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-1.4.3.tgz",
+      "integrity": "sha512-MdJqjpodkS5J149zN0Po+HPshkTdUyrvF7CKTafUgv69vBSPtncrj+3IiUgqdd7ElIEkbeXCsEouBUwLrw9Ilg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.27.0",
+        "pathe": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16.14.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/ast-walker-scope": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/ast-walker-scope/-/ast-walker-scope-0.6.2.tgz",
+      "integrity": "sha512-1UWOyC50xI3QZkRuDj6PqDtpm1oHWtYs+NQGwqL/2R11eN3Q81PHAHPM0SWW3BNQm53UDwS//Jv8L4CCVLM1bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.3",
+        "ast-kit": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=16.14.0"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/magic-string-ast": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/magic-string-ast/-/magic-string-ast-0.7.1.tgz",
+      "integrity": "sha512-ub9iytsEbT7Yw/Pd29mSo/cNQpaEu67zR1VVcXDiYjSFwzeBxNdTd0FMnSslLQXiRj8uGPzwsaoefrMD5XAmdw==",
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17"
+      },
+      "engines": {
+        "node": ">=16.14.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/oxc-parser": {
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.70.0.tgz",
+      "integrity": "sha512-YbqTuQDDIYwQF/li0VFK5uTbmHV4jWFeQQONkPdf77vz+JMiq7SusmcSVZ4hBrGM+3WyLdKH5S7spnvz4XVVzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.70.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-darwin-arm64": "0.70.0",
+        "@oxc-parser/binding-darwin-x64": "0.70.0",
+        "@oxc-parser/binding-freebsd-x64": "0.70.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.70.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.70.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.70.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.70.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.70.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.70.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.70.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.70.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.70.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.70.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.70.0"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/unplugin-utils": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.2.5.tgz",
+      "integrity": "sha512-gwXJnPRewT4rT7sBi/IvxKTjsms7jX7QIDLOClApuZwR49SXbrB1z2NLUZ+vDHyqCj/n58OzRRqaW+B8OZi8vg==",
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/unplugin-vue-router": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/unplugin-vue-router/-/unplugin-vue-router-0.12.0.tgz",
+      "integrity": "sha512-xjgheKU0MegvXQcy62GVea0LjyOdMxN0/QH+ijN29W62ZlMhG7o7K+0AYqfpprvPwpWtuRjiyC5jnV2SxWye2w==",
+      "deprecated": "Merged into vuejs/router. Migrate: https://router.vuejs.org/guide/migration/v4-to-v5.html",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.8",
+        "@vue-macros/common": "^1.16.1",
+        "ast-walker-scope": "^0.6.2",
+        "chokidar": "^4.0.3",
+        "fast-glob": "^3.3.3",
+        "json5": "^2.2.3",
+        "local-pkg": "^1.0.0",
+        "magic-string": "^0.30.17",
+        "micromatch": "^4.0.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.2",
+        "scule": "^1.3.0",
+        "unplugin": "^2.2.0",
+        "unplugin-utils": "^0.2.3",
+        "yaml": "^2.7.0"
+      },
+      "peerDependencies": {
+        "vue-router": "^4.4.0"
+      },
+      "peerDependenciesMeta": {
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nuxtjs/i18n/node_modules/unplugin-vue-router/node_modules/@vue-macros/common": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-1.16.1.tgz",
+      "integrity": "sha512-Pn/AWMTjoMYuquepLZP813BIcq8DTZiNCoaceuNlvaYuOTd8DqBZWc5u0uOMQZMInwME1mdSmmBAcTluiV9Jtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-sfc": "^3.5.13",
+        "ast-kit": "^1.4.0",
+        "local-pkg": "^1.0.0",
+        "magic-string-ast": "^0.7.0",
+        "pathe": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.14.0"
+      },
+      "peerDependencies": {
+        "vue": "^2.7.0 || ^3.2.25"
+      },
+      "peerDependenciesMeta": {
+        "vue": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nuxtjs/tailwindcss": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@nuxtjs/tailwindcss/-/tailwindcss-6.14.0.tgz",
@@ -1826,9 +3144,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1844,9 +3159,6 @@
       "integrity": "sha512-C3zapJconWpl2Y7LR3GkRkH6jxpuV2iVUfkFcHT5Ffn4Zu7l88mZa2dhcfdULZDybN1Phka/P34YUzuskUUrXw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1864,9 +3176,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1882,9 +3191,6 @@
       "integrity": "sha512-MKLjpldYkeoB4T+yAi4aIAb0waifxUjLcKkCUDmYAY3RqBJTvWK34KtfaKZL0IBMIXfD92CbKkcxQirDUS9Xcg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1902,9 +3208,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1920,9 +3223,6 @@
       "integrity": "sha512-B9GyPQ1NKbvpETVAMyJMfRlD3c6UJ7kiuFUAlx9LTYiQL+YIyT6vpuRlq1zgsXxavZluVrfeJv6x0owV4KDx4Q==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1940,9 +3240,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1958,9 +3255,6 @@
       "integrity": "sha512-jFBgGbx1oLadb83ntJmy1dWlAHSQanXTS21G4PgkxyONmxZdZ/UMKr7KsADzMuoPsd2YhJHxzRpwJd9U+4BFBw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2170,9 +3464,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2188,9 +3479,6 @@
       "integrity": "sha512-QagKTDF4lrz8bCXbUi39Uq5xs7C7itAseKm51f33U+Dyar9eJY/zGKqfME9mKLOiahX7Fc1J3xMWVS0AdDXLPg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2208,9 +3496,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2226,9 +3511,6 @@
       "integrity": "sha512-ur/WVZF9FSOiZGxyP+nfxZzuv6r5OJDYoVxJnUR7fM/hhXLh4V/be6rjbzm9KLCDBRwYCEKJtt+XXNccwd06IA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2246,9 +3528,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2264,9 +3543,6 @@
       "integrity": "sha512-hbsfKjUwRjcMZZvvmpZSc+qS0bHcHRu8aV/I3Ikn9BzOA0ZAgUE7ctPtce5zCU7bM8dnTLi4sJ1Pi9YHdx6Urw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2284,9 +3560,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2302,9 +3575,6 @@
       "integrity": "sha512-gRvK6HPzF5ITRL68fqb2WYYs/hGviPIbkV84HWCgiJX+LkaOpp+HIHQl3zVZdyKHwopXToTbXbtx/oFjDjl8pg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2393,6 +3663,28 @@
       ],
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/wasm": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/wasm/-/wasm-0.60.0.tgz",
+      "integrity": "sha512-Dkf9/D87WGBCW3L0+1DtpAfL4SrNsgeRvxwjpKCtbH7Kf6K+pxrT0IridaJfmWKu1Ml+fDvj+7HEyBcfUC/TXQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.60.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxc-parser/wasm/node_modules/@oxc-project/types": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.60.0.tgz",
+      "integrity": "sha512-prhfNnb3ATFHOCv7mzKFfwLij5RzoUz6Y1n525ZhCEqfq5wreCXL+DyVoq3ShukPo7q45ZjYIdjFUgjj+WKzng==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -2523,9 +3815,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2541,9 +3830,6 @@
       "integrity": "sha512-ykxpPQp0eAcSmhy0Y3qKvdanHY4d8THPonDfmCoktUXb6r0X6qnjpJB3V+taN1wevW55bOEZd97kxtjTKjqhmg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2561,9 +3847,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2579,9 +3862,6 @@
       "integrity": "sha512-Dr2ZW9ZZ4l1eQ5JUEUY3smBh4JFPCPuybWaDZTLn3ADZjyd8ZtNXEjeMT8rQbbhbgSL9hEgbwaqraole3FNThQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2599,9 +3879,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2617,9 +3894,6 @@
       "integrity": "sha512-qT//IAPLvse844t99Kff5j055qEbXfwzWgvCMb0FyjisnB8foy25iHZxZIocNBe6qwrCYWUP1M8rNrB/WyfS1Q==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2637,9 +3911,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2655,9 +3926,6 @@
       "integrity": "sha512-3wqWbTSaIFZvDr1aqmTul4cg8PRWYh6VC52E8bLI7ytgS/BwJLW+sDUU2YaGIds4sAf/1yKeJRmudRCDPW9INg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2870,9 +4138,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2892,9 +4157,6 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2916,9 +4178,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2938,9 +4197,6 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2962,9 +4218,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2984,9 +4237,6 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3314,6 +4564,28 @@
         }
       }
     },
+    "node_modules/@rollup/plugin-yaml": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-yaml/-/plugin-yaml-4.1.2.tgz",
+      "integrity": "sha512-RpupciIeZMUqhgFE97ba0s98mOFS7CWzN3EJNhJkqSv9XLlWYtwVdtE6cDw6ASOF/sZVFS7kRJXftaqM2Vakdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "js-yaml": "^4.1.0",
+        "tosource": "^2.0.0-alpha.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
@@ -3421,9 +4693,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3436,9 +4705,6 @@
       "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3453,9 +4719,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3468,9 +4731,6 @@
       "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3485,9 +4745,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3500,9 +4757,6 @@
       "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3517,9 +4771,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3532,9 +4783,6 @@
       "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3549,9 +4797,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3564,9 +4809,6 @@
       "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3581,9 +4823,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3597,9 +4836,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3612,9 +4848,6 @@
       "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3740,10 +4973,22 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "license": "MIT"
     },
     "node_modules/@types/resolve": {
@@ -3751,6 +4996,129 @@
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.2.tgz",
+      "integrity": "sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.57.2",
+        "@typescript-eslint/types": "^8.57.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.2.tgz",
+      "integrity": "sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.2.tgz",
+      "integrity": "sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.2.tgz",
+      "integrity": "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.2.tgz",
+      "integrity": "sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.57.2",
+        "@typescript-eslint/tsconfig-utils": "8.57.2",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.2.tgz",
+      "integrity": "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.2",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/@unhead/vue": {
       "version": "2.1.12",
@@ -3956,6 +5324,7 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.31.tgz",
       "integrity": "sha512-M8wpPgR9UJ8MiRGjppvx9uWJfLV7A/T+/rL8s/y3QG3u0c2/YZgff3d6SuimKRIhcYnWg5fTfDMlz2E6seUW8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.2",
         "@vue/compiler-core": "3.5.31",
@@ -4152,6 +5521,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4168,6 +5538,15 @@
         "acorn": "^8"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -4175,6 +5554,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/alien-signals": {
@@ -4379,6 +5774,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/ast-kit": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
@@ -4497,6 +5898,7 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -4695,6 +6097,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4806,6 +6209,7 @@
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4966,6 +6370,7 @@
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
       "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "consola": "^3.2.3"
       }
@@ -5529,6 +6934,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -5959,11 +7370,257 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
+      "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.3",
+        "@eslint/config-helpers": "^0.5.3",
+        "@eslint/core": "^1.1.1",
+        "@eslint/plugin-kit": "^0.6.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -6048,6 +7705,12 @@
       "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
@@ -6069,6 +7732,18 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "license": "MIT"
     },
     "node_modules/fast-npm-meta": {
       "version": "1.4.2",
@@ -6115,6 +7790,18 @@
         }
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -6132,6 +7819,41 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "license": "ISC"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -6675,6 +8397,15 @@
         "unplugin-utils": "^0.3.1"
       }
     },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -7016,6 +8747,18 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -7028,6 +8771,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -7038,6 +8799,41 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonc-eslint-parser": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.2.tgz",
+      "integrity": "sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.5.0",
+        "eslint-visitor-keys": "^3.0.0",
+        "espree": "^9.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      }
+    },
+    "node_modules/jsonc-eslint-parser/node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/jsonfile": {
@@ -7064,6 +8860,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/kleur": {
@@ -7331,6 +9136,19 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -7407,6 +9225,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lodash": {
@@ -7778,6 +9611,12 @@
       "integrity": "sha512-Kv2JYYiCzt16Kt5QwAc9BFG89xfPNBx+oQL4GQXD9nLqPkZBiNaqaCWtwnbk/q7UVsTYevvM1b0UF8zmEI4pCg==",
       "license": "MIT"
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -8025,6 +9864,7 @@
       "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.21.2.tgz",
       "integrity": "sha512-XzZFj2KMK16zE0TfrGpjvgc378wZWvDzIpunHOHOT0Jj8zbV5qT1uQKaJb+fAHv6lf1A4nOMMWHrTmjAK4u0Zg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dxup/nuxt": "^0.4.0",
         "@nuxt/cli": "^3.34.0",
@@ -8271,6 +10111,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/oxc-minify": {
       "version": "0.117.0",
       "resolved": "https://registry.npmjs.org/oxc-minify/-/oxc-minify-0.117.0.tgz",
@@ -8310,6 +10168,7 @@
       "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.117.0.tgz",
       "integrity": "sha512-l3cbgK5wUvWDVNWM/JFU77qDdGZK1wudnLsFcrRyNo/bL1CyU8pC25vDhMHikVY29lbK2InTWsX42RxVSutUdQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "^0.117.0"
       },
@@ -8388,6 +10247,36 @@
         "oxc-parser": ">=0.98.0"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -8408,6 +10297,15 @@
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "license": "MIT"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
@@ -8511,6 +10409,7 @@
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.3.1.tgz",
       "integrity": "sha512-khUlZSwt9xXCaTbbxFYBKDc/bWAGWJjOgvxETwkTN7KRm66EeT1ZdZj6i2ceh9sP2Pzqsbc704r2yngBrxBVug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.6.3",
         "vue-demi": "^0.14.10"
@@ -8582,6 +10481,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9131,6 +11031,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -9188,6 +11089,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-7.1.0.tgz",
@@ -9214,6 +11124,15 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/quansync": {
       "version": "0.2.11",
@@ -9677,6 +11596,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
       "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10474,6 +12394,7 @@
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -10783,6 +12704,14 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tosource": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/tosource/-/tosource-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-KAB2lrSS48y91MzFPFuDg4hLbvDiyTjOVgaK7Erw+5AmZXNq4sFRVn8r6yxSLuNs15PaokrDRpS61ERY9uZOug==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/totalist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -10797,6 +12726,18 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
@@ -10820,6 +12761,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6.x"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/type-fest": {
@@ -10885,6 +12838,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11301,6 +13255,15 @@
       "integrity": "sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA==",
       "license": "MIT"
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -11322,6 +13285,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11686,6 +13650,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.31.tgz",
       "integrity": "sha512-iV/sU9SzOlmA/0tygSmjkEN6Jbs3nPoIPFhCMLD2STrjgOU8DX7ZtzMhg4ahVwf5Rp9KoFzcXeB1ZrVbLBp5/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.31",
         "@vue/compiler-sfc": "3.5.31",
@@ -11743,11 +13708,33 @@
       "integrity": "sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==",
       "license": "MIT"
     },
+    "node_modules/vue-i18n": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-10.0.8.tgz",
+      "integrity": "sha512-mIjy4utxMz9lMMo6G9vYePv7gUFt4ztOMhY9/4czDJxZ26xPeJ49MAGa9wBAE3XuXbYCrtVPmPxNjej7JJJkZQ==",
+      "deprecated": "v9 and v10 no longer supported. please migrate to v11. about maintenance status, see https://vue-i18n.intlify.dev/guide/maintenance.html",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "10.0.8",
+        "@intlify/shared": "10.0.8",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
     "node_modules/vue-router": {
       "version": "4.6.4",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
       "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.6.4"
       },
@@ -11793,6 +13780,15 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {
@@ -11947,6 +13943,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -11955,6 +13952,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yaml-eslint-parser": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-1.3.2.tgz",
+      "integrity": "sha512-odxVsHAkZYYglR30aPYRY4nUGJnoJ2y1ww2HDvZALo0BDETv9kWbi16J52eHs+PWRNmF4ub6nZqfVOeesOvntg==",
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.0.0",
+        "yaml": "^2.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
       }
     },
     "node_modules/yargs": {
@@ -11991,6 +14004,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/youch": {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
     "generate": "nuxt generate"
   },
   "dependencies": {
-    "nuxt": "^3.15.0",
-    "vue": "^3.5.0",
+    "@nuxtjs/i18n": "^9.5.6",
     "@pinia/nuxt": "^0.9.0",
-    "pinia": "^2.3.0"
+    "nuxt": "^3.15.0",
+    "pinia": "^2.3.0",
+    "vue": "^3.5.0"
   },
   "devDependencies": {
     "@nuxtjs/tailwindcss": "^6.13.0",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -24,21 +24,21 @@
               disabled
               class="btn btn-disabled btn-block h-14 text-base font-semibold rounded-xl"
             >
-              Ciclo completado
+              {{ $t('timer.cycleCompleted') }}
             </button>
             <button
               v-else-if="countdown.isActive"
               class="btn btn-error btn-outline btn-block h-14 text-base font-semibold rounded-xl"
               @click="setCountdownState(false)"
             >
-              Abandonar ciclo
+              {{ $t('timer.abandonCycle') }}
             </button>
             <button
               v-else
               class="btn btn-primary btn-block h-14 text-base font-semibold rounded-xl shadow-lg shadow-primary/20 hover:shadow-primary/40 transition-shadow duration-300"
               @click="setCountdownState(true)"
             >
-              Iniciar ciclo
+              {{ $t('timer.startCycle') }}
             </button>
           </div>
         </div>
@@ -77,6 +77,7 @@ import Countdown from '~/components/molecules/Countdown.vue'
 import Card from '~/components/organisms/Card.vue'
 import { scrollToElement, getRandomNumber, playAudio, sendNotification } from '~/utils'
 
+const { t } = useI18n()
 useHead({ title: 'Pomodoro | Move.it' })
 
 const challenges = useChallengesStore()
@@ -112,8 +113,8 @@ function getNewChallenge() {
   if ('Notification' in window && Notification.permission === 'granted') {
     playAudio('/notification.mp3')
     const challenge = challenges.currentChallenge
-    sendNotification('Ciclo completado!', {
-      body: challenge ? challenge.description : 'Novo desafio disponivel!',
+    sendNotification(t('notifications.cycleCompleted'), {
+      body: challenge ? challenge.description : t('notifications.newChallenge'),
       icon: '/favicon.png',
       tag: 'pomodoro-challenge',
     })


### PR DESCRIPTION
## Changes

### 1. Internacionalizacao (i18n)
- Added @nuxtjs/i18n with PT-BR (default) and EN locales
- Created LanguageSelector component in navbar with dropdown
- Translated all UI text across all components using $t() and t()
- Language preference saved to localStorage and restored on page load
- Added missing i18n keys: githubPlaceholder, namePlaceholder, defaultName
- Replaced hardcoded Portuguese placeholders in Profile with i18n keys

### 2. PiP Theme Inheritance
- PiP window now reads DaisyUI CSS variables from the parent document
- Fixed critical bug: syncDaisyUITheme() was double-wrapping OKLCH values
  - getComputedStyle returns oklch() wrapped values
  - Old code: oklch(oklch(...)) = invalid CSS
  - Added extractOklchValues() helper to strip wrapper
- Theme updates dynamically when changed via watcher
- Works with both Document PiP API (Chrome/Edge) and window.open fallback

### 3. Branch Cleanup
- Remote branches already clean (only develop/master remain)
- 5 merged branches were previously deleted (feature/pip-final, feature/pip-notifications, feature/pip-polished, feature/pip-simple, fix/pip-ssr)

### Technical Details
- i18n files: i18n/pt-BR.json and i18n/en.json
- PiP reads CSS vars via getComputedStyle, extracts raw OKLCH components
- Build passes successfully