### PR TITLE
feat: GitHub OAuth como login principal + correção TimerPresets

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,8 @@
 import { Hono } from 'hono'
 import type { Env } from '../types/env'
 import { cors } from 'hono/cors'
+import { getCookie } from 'hono/cookie'
+import { getAuth } from './services/auth'
 import profile from './routes/profile'
 import sessions from './routes/sessions'
 import stats from './routes/stats'
@@ -19,8 +21,22 @@ app.use('*', cors({
 // Health check
 app.get('/api/health', (c) => c.json({ status: 'ok', timestamp: new Date().toISOString() }))
 
-// Auth routes (Better Auth)
+// Custom auth routes (sign-in, sign-up, sign-out, session, github-enabled, github-login)
 app.route('/api/auth', authRoutes)
+
+// Better Auth handler for OAuth flows (GitHub OAuth signin/callback)
+// Mounts at /api/better-auth/* to avoid conflicts with custom routes
+app.all('/api/better-auth/*', async (c) => {
+  const auth = getAuth({
+    DB: c.env.DB,
+    BETTER_AUTH_SECRET: c.env.BETTER_AUTH_SECRET,
+    BETTER_AUTH_URL: c.env.BETTER_AUTH_URL,
+    GITHUB_CLIENT_ID: c.env.GITHUB_CLIENT_ID,
+    GITHUB_CLIENT_SECRET: c.env.GITHUB_CLIENT_SECRET,
+  })
+
+  return auth.handler(c.req.raw)
+})
 
 // Pomodoro routes
 app.route('/api/pomodoro/profile', profile)

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -7,6 +7,8 @@ interface Env {
   KV: KVNamespace
   BETTER_AUTH_SECRET: string
   BETTER_AUTH_URL: string
+  GITHUB_CLIENT_ID?: string
+  GITHUB_CLIENT_SECRET?: string
 }
 
 interface PomodoroUser {
@@ -14,6 +16,7 @@ interface PomodoroUser {
   email: string
   name: string
   avatarUrl?: string | null
+  githubUsername?: string | null
   [key: string]: unknown
 }
 
@@ -29,6 +32,8 @@ function getAuthFromContext(c: { env: Env }) {
     DB: c.env.DB,
     BETTER_AUTH_SECRET: c.env.BETTER_AUTH_SECRET,
     BETTER_AUTH_URL: c.env.BETTER_AUTH_URL,
+    GITHUB_CLIENT_ID: c.env.GITHUB_CLIENT_ID,
+    GITHUB_CLIENT_SECRET: c.env.GITHUB_CLIENT_SECRET,
   })
 }
 
@@ -213,4 +218,25 @@ authRoutes.get('/session', async (c) => {
   } catch {
     return c.json({ user: null, session: null }, 401)
   }
+})
+
+// Check if GitHub OAuth is enabled
+authRoutes.get('/github-enabled', async (c) => {
+  const enabled = !!(c.env.GITHUB_CLIENT_ID && c.env.GITHUB_CLIENT_SECRET)
+  return c.json({ enabled })
+})
+
+// Get GitHub OAuth URL
+authRoutes.get('/github-login', async (c) => {
+  const enabled = !!(c.env.GITHUB_CLIENT_ID && c.env.GITHUB_CLIENT_SECRET)
+  if (!enabled) {
+    return c.json({ error: 'GitHub OAuth não configurado' }, 400)
+  }
+
+  const callbackURL = c.req.query('callbackURL') || `${c.env.BETTER_AUTH_URL}/api/better-auth/callback/github`
+  const baseURL = c.env.BETTER_AUTH_URL || `${new URL(c.req.url).origin}`
+
+  return c.json({
+    url: `${baseURL}/api/better-auth/sign-in/social?provider=github&callbackURL=${encodeURIComponent(callbackURL)}`,
+  })
 })

--- a/apps/api/src/services/auth.ts
+++ b/apps/api/src/services/auth.ts
@@ -1,15 +1,35 @@
 import { betterAuth } from 'better-auth'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
+import { github } from 'better-auth/social-providers'
 import { drizzle } from 'drizzle-orm/d1'
 
 interface AuthEnv {
   DB: D1Database
   BETTER_AUTH_SECRET: string
   BETTER_AUTH_URL: string
+  GITHUB_CLIENT_ID?: string
+  GITHUB_CLIENT_SECRET?: string
 }
 
 export function createAuth(env: AuthEnv) {
   const db = drizzle(env.DB, { casing: 'snake_case' })
+
+  const socialProviders = []
+
+  // Add GitHub OAuth if credentials are configured
+  if (env.GITHUB_CLIENT_ID && env.GITHUB_CLIENT_SECRET) {
+    socialProviders.push(
+      github({
+        clientId: env.GITHUB_CLIENT_ID,
+        clientSecret: env.GITHUB_CLIENT_SECRET,
+        mapProfileToUser: (profile) => ({
+          name: profile.name || profile.login,
+          email: profile.email,
+          image: profile.avatar_url,
+        }),
+      })
+    )
+  }
 
   return betterAuth({
     database: drizzleAdapter(db, {
@@ -22,6 +42,7 @@ export function createAuth(env: AuthEnv) {
       requireEmailVerification: false,
       minPasswordLength: 6,
     },
+    socialProviders: socialProviders.length > 0 ? socialProviders : undefined,
     session: {
       expiresIn: 60 * 60 * 24 * 30, // 30 days
       updateAge: 60 * 60 * 24, // 1 day
@@ -31,7 +52,7 @@ export function createAuth(env: AuthEnv) {
     },
     account: {
       accountLinking: {
-        enabled: false,
+        enabled: true, // Allow linking accounts from same email
       },
     },
     advanced: {

--- a/apps/api/src/types/env.ts
+++ b/apps/api/src/types/env.ts
@@ -3,4 +3,6 @@ export interface Env {
   KV: KVNamespace
   BETTER_AUTH_SECRET: string
   BETTER_AUTH_URL: string
+  GITHUB_CLIENT_ID?: string
+  GITHUB_CLIENT_SECRET?: string
 }

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -18,3 +18,6 @@ id = "pomodoro-kv-id"
 [vars]
 BETTER_AUTH_SECRET = "dev-secret-change-in-production"
 BETTER_AUTH_URL = "http://localhost:8787"
+# GitHub OAuth - configure via: wrangler secret put GITHUB_CLIENT_ID
+# GITHUB_CLIENT_ID = ""
+# GITHUB_CLIENT_SECRET = ""

--- a/apps/web/components/atoms/TimerPresets.vue
+++ b/apps/web/components/atoms/TimerPresets.vue
@@ -23,8 +23,8 @@
         </h3>
       </div>
 
-      <!-- Preset buttons -->
-      <div class="flex flex-wrap gap-2 mb-3">
+      <!-- Preset buttons - grid 3 cols with uniform gap -->
+      <div class="grid grid-cols-3 gap-2 mb-3">
         <button
           v-for="preset in presets"
           :key="preset"
@@ -37,38 +37,36 @@
         </button>
       </div>
 
-      <!-- Custom input -->
-      <div class="form-control">
-        <div class="grid grid-cols-[1fr_auto] gap-2 items-end">
-          <div>
-            <label class="label py-1">
-              <span class="label-text text-xs">{{ $t('timer.customTime') }}</span>
-            </label>
-            <input
-              v-model.number="customInput"
-              type="number"
-              min="1"
-              max="120"
-              placeholder="25"
-              class="input input-bordered input-sm w-full"
-              :disabled="countdown.isActive"
-              @keyup.enter="applyCustom"
-            >
-          </div>
-          <button
-            class="btn btn-sm btn-outline self-end"
-            :disabled="countdown.isActive || !customInput || customInput < 1"
-            @click="applyCustom"
+      <!-- Custom input + Apply aligned -->
+      <div class="flex gap-2 items-end">
+        <div class="flex-1">
+          <label class="label py-1">
+            <span class="label-text text-xs">{{ $t('timer.customTime') }}</span>
+          </label>
+          <input
+            v-model.number="customInput"
+            type="number"
+            min="1"
+            max="120"
+            placeholder="25"
+            class="input input-bordered input-sm w-full"
+            :disabled="countdown.isActive"
+            @keyup.enter="applyCustom"
           >
-            {{ $t('timer.apply') }}
-          </button>
         </div>
+        <button
+          class="btn btn-sm btn-primary shrink-0 h-9"
+          :disabled="countdown.isActive || !customInput || customInput < 1"
+          @click="applyCustom"
+        >
+          {{ $t('timer.apply') }}
+        </button>
       </div>
 
-      <!-- Reset button -->
+      <!-- Reset button aligned with grid -->
       <button
-        class="btn btn-sm mt-5 gap-1 w-full"
-        :class="countdown.isActive ? 'btn-error' : 'btn-ghost'"
+        class="btn btn-sm mt-3 gap-1 w-full"
+        :class="countdown.isActive ? 'btn-error' : 'btn-ghost btn-outline'"
         :disabled="!countdown.isActive && countdown.time === countdown.customMinutes * 60"
         @click="resetTimer"
       >

--- a/apps/web/composables/useAuth.ts
+++ b/apps/web/composables/useAuth.ts
@@ -5,6 +5,7 @@ export interface AuthUser {
   email: string
   name: string
   avatarUrl: string | null
+  githubUsername?: string | null
 }
 
 export interface AuthSession {
@@ -126,6 +127,10 @@ export function useAuth() {
     return authUser.value !== null
   }
 
+  function isGitHubUser(): boolean {
+    return !!authUser.value?.githubUsername
+  }
+
   return {
     user: authUser,
     session: authSession,
@@ -135,5 +140,6 @@ export function useAuth() {
     logout,
     fetchSession,
     isAuthenticated,
+    isGitHubUser,
   }
 }

--- a/apps/web/i18n/en.json
+++ b/apps/web/i18n/en.json
@@ -46,7 +46,10 @@
 		"optional": "Login is optional. The app works without an account.",
 		"orContinue": "or continue without account",
 		"skip": "Continue without login",
-		"loggedOut": "You have been logged out"
+		"loggedOut": "You have been logged out",
+		"loginWithGitHub": "Sign in with GitHub",
+		"emailPassword": "Sign in with Email and Password",
+		"or": "or"
 	},
 	"challenges": {
 		"completedChallenges": "Completed challenges",

--- a/apps/web/i18n/pt-BR.json
+++ b/apps/web/i18n/pt-BR.json
@@ -46,7 +46,10 @@
 		"optional": "Login e opcional. O app funciona sem conta.",
 		"orContinue": "ou continue sem conta",
 		"skip": "Continuar sem login",
-		"loggedOut": "Voce saiu da sua conta"
+		"loggedOut": "Voce saiu da sua conta",
+		"loginWithGitHub": "Entrar com GitHub",
+		"emailPassword": "Entrar com E-mail e Senha",
+		"or": "ou"
 	},
 	"challenges": {
 		"completedChallenges": "Desafios completados",

--- a/apps/web/layouts/default.vue
+++ b/apps/web/layouts/default.vue
@@ -295,6 +295,14 @@
                   {{ $t('sync.login') }}
                 </NuxtLink>
               </li>
+              <li v-if="!isAuthenticated">
+                <button @click="handleGitHubLogin">
+                  <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
+                  </svg>
+                  {{ $t('auth.loginWithGitHub', 'Entrar com GitHub') }}
+                </button>
+              </li>
               <li v-else>
                 <button class="text-error" @click="handleLogout">
                   <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -349,7 +357,7 @@
             >
               Willian
             </a>
-            <span>e</span>
+            <span>{{ $t('footer.and') }}</span>
             <a
               href="https://github.com/Morgana-Claw"
               target="_blank"
@@ -396,6 +404,9 @@ const { soundEnabled, toggleSound, initFromStorage: initSound } = useSound()
 const { canInstall, install: installPwaNative } = usePwaInstall()
 const { logout: authLogout, fetchSession } = useAuth()
 const authUser = useAuthUser()
+
+const config = useRuntimeConfig()
+const apiBase = config.public.apiBase as string || ''
 
 // Refs for modals
 const editProfileRef = ref<InstanceType<typeof EditProfileModal> | null>(null)
@@ -459,6 +470,17 @@ async function installPwa() {
 async function handleLogout() {
   ;(document.activeElement as HTMLElement)?.blur()
   await authLogout()
+}
+
+async function handleGitHubLogin() {
+  ;(document.activeElement as HTMLElement)?.blur()
+  try {
+    const res = await $fetch<{ url: string }>(`${apiBase}/api/auth/github-login`)
+    navigateTo(res.url, { external: true })
+  } catch {
+    // GitHub OAuth not configured, fallback to login page
+    navigateTo('/login')
+  }
 }
 
 onMounted(() => {

--- a/apps/web/pages/history.vue
+++ b/apps/web/pages/history.vue
@@ -162,7 +162,7 @@ const fireEmoji = computed(() => {
 })
 
 function formatTime(timestamp: number): string {
-  return new Date(timestamp).toLocaleTimeString('pt-BR', {
+  return new Date(timestamp).toLocaleTimeString(locale.value === 'pt-BR' ? 'pt-BR' : 'en', {
     hour: '2-digit',
     minute: '2-digit',
   })
@@ -175,12 +175,12 @@ function formatDayLabel(dayKey: string): string {
   yesterday.setDate(yesterday.getDate() - 1)
   const yesterdayKey = `${yesterday.getFullYear()}-${String(yesterday.getMonth() + 1).padStart(2, '0')}-${String(yesterday.getDate()).padStart(2, '0')}`
 
-  if (dayKey === todayKey) return 'Hoje'
-  if (dayKey === yesterdayKey) return 'Ontem'
+  if (dayKey === todayKey) return t('history.today')
+  if (dayKey === yesterdayKey) return t('history.yesterday')
 
   const [year, month, day] = dayKey.split('-')
   const date = new Date(parseInt(year), parseInt(month) - 1, parseInt(day))
-  return date.toLocaleDateString('pt-BR', {
+  return date.toLocaleDateString(locale.value === 'pt-BR' ? 'pt-BR' : 'en', {
     weekday: 'short',
     day: 'numeric',
     month: 'short',

--- a/apps/web/pages/login.vue
+++ b/apps/web/pages/login.vue
@@ -24,105 +24,129 @@
 
     <div class="card bg-base-200 w-full max-w-sm shadow-lg mt-16">
       <div class="card-body">
-        <!-- Tabs -->
-        <div class="tabs tabs-boxed justify-center mb-4">
-          <button
-            class="tab"
-            :class="{ 'tab-active': mode === 'login' }"
-            @click="mode = 'login'"
-          >
-            {{ $t('auth.signIn', 'Entrar') }}
-          </button>
-          <button
-            class="tab"
-            :class="{ 'tab-active': mode === 'signup' }"
-            @click="mode = 'signup'"
-          >
-            {{ $t('auth.signUp', 'Criar Conta') }}
-          </button>
-        </div>
+        <!-- GitHub OAuth - Primary option -->
+        <button
+          class="btn btn-block gap-3 bg-[#24292e] hover:bg-[#2f363d] text-white border-none"
+          :disabled="isLoading || !githubEnabled"
+          @click="handleGitHubLogin"
+        >
+          <svg v-if="!isLoading" class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
+          </svg>
+          <span v-if="isLoading" class="loading loading-spinner loading-sm" />
+          <span v-else>{{ $t('auth.loginWithGitHub', 'Entrar com GitHub') }}</span>
+        </button>
 
-        <form @submit.prevent="handleSubmit" class="flex flex-col gap-4">
-          <!-- Name (signup only) -->
-          <div v-if="mode === 'signup'" class="form-control">
-            <label class="label">
-              <span class="label-text font-medium">
-                {{ $t('auth.name', 'Nome') }} <span class="text-error">*</span>
-              </span>
-            </label>
-            <input
-              v-model="name"
-              type="text"
-              :placeholder="$t('auth.namePlaceholder', 'Seu nome')"
-              class="input input-bordered w-full"
-              :disabled="isLoading"
-              required
-            >
+        <div class="divider text-xs">{{ $t('auth.or', 'ou') }}</div>
+
+        <!-- Email/Password - Secondary option -->
+        <div class="collapse collapse-arrow bg-base-300/50">
+          <input type="checkbox" v-model="showEmailForm" />
+          <div class="collapse-title text-sm font-medium min-h-0 py-3">
+            {{ $t('auth.emailPassword', 'Entrar com E-mail e Senha') }}
           </div>
-
-          <!-- Email -->
-          <div class="form-control">
-            <label class="label">
-              <span class="label-text font-medium">
-                {{ $t('auth.email', 'E-mail') }} <span class="text-error">*</span>
-              </span>
-            </label>
-            <input
-              v-model="email"
-              type="email"
-              placeholder="seu@email.com"
-              class="input input-bordered w-full"
-              :disabled="isLoading"
-              required
-            >
-          </div>
-
-          <!-- Password -->
-          <div class="form-control">
-            <label class="label">
-              <span class="label-text font-medium">
-                {{ $t('auth.password', 'Senha') }} <span class="text-error">*</span>
-              </span>
-            </label>
-            <div class="relative">
-              <input
-                v-model="password"
-                :type="showPassword ? 'text' : 'password'"
-                :placeholder="$t('auth.passwordPlaceholder', 'Sua senha')"
-                class="input input-bordered w-full pr-10"
-                :disabled="isLoading"
-                required
-              >
+          <div class="collapse-content px-4">
+            <!-- Tabs -->
+            <div class="tabs tabs-boxed justify-center mb-3">
               <button
-                type="button"
-                class="absolute right-3 top-1/2 -translate-y-1/2 text-base-content/50 hover:text-base-content"
-                @click="showPassword = !showPassword"
-                :disabled="isLoading"
+                class="tab tab-sm"
+                :class="{ 'tab-active': mode === 'login' }"
+                @click="mode = 'login'"
               >
-                <svg v-if="!showPassword" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
-                <svg v-else xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
+                {{ $t('auth.signIn', 'Entrar') }}
+              </button>
+              <button
+                class="tab tab-sm"
+                :class="{ 'tab-active': mode === 'signup' }"
+                @click="mode = 'signup'"
+              >
+                {{ $t('auth.signUp', 'Criar Conta') }}
               </button>
             </div>
+
+            <form @submit.prevent="handleSubmit" class="flex flex-col gap-3">
+              <!-- Name (signup only) -->
+              <div v-if="mode === 'signup'" class="form-control">
+                <label class="label">
+                  <span class="label-text font-medium text-xs">
+                    {{ $t('auth.name', 'Nome') }} <span class="text-error">*</span>
+                  </span>
+                </label>
+                <input
+                  v-model="name"
+                  type="text"
+                  :placeholder="$t('auth.namePlaceholder', 'Seu nome')"
+                  class="input input-bordered input-sm w-full"
+                  :disabled="isLoading"
+                  required
+                >
+              </div>
+
+              <!-- Email -->
+              <div class="form-control">
+                <label class="label">
+                  <span class="label-text font-medium text-xs">
+                    {{ $t('auth.email', 'E-mail') }} <span class="text-error">*</span>
+                  </span>
+                </label>
+                <input
+                  v-model="email"
+                  type="email"
+                  placeholder="seu@email.com"
+                  class="input input-bordered input-sm w-full"
+                  :disabled="isLoading"
+                  required
+                >
+              </div>
+
+              <!-- Password -->
+              <div class="form-control">
+                <label class="label">
+                  <span class="label-text font-medium text-xs">
+                    {{ $t('auth.password', 'Senha') }} <span class="text-error">*</span>
+                  </span>
+                </label>
+                <div class="relative">
+                  <input
+                    v-model="password"
+                    :type="showPassword ? 'text' : 'password'"
+                    :placeholder="$t('auth.passwordPlaceholder', 'Sua senha')"
+                    class="input input-bordered input-sm w-full pr-10"
+                    :disabled="isLoading"
+                    required
+                  >
+                  <button
+                    type="button"
+                    class="absolute right-3 top-1/2 -translate-y-1/2 text-base-content/50 hover:text-base-content"
+                    @click="showPassword = !showPassword"
+                    :disabled="isLoading"
+                  >
+                    <svg v-if="!showPassword" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                    <svg v-else xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
+                  </button>
+                </div>
+              </div>
+
+              <!-- Error -->
+              <div v-if="error" class="alert alert-error text-xs py-2">
+                <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-4 w-4" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                <span>{{ error }}</span>
+              </div>
+
+              <!-- Submit -->
+              <button
+                type="submit"
+                class="btn btn-primary btn-sm w-full"
+                :disabled="isLoading"
+              >
+                <span v-if="isLoading" class="loading loading-spinner loading-sm" />
+                <span v-else>{{ mode === 'login' ? $t('auth.signIn', 'Entrar') : $t('auth.signUp', 'Criar Conta') }}</span>
+              </button>
+            </form>
           </div>
+        </div>
 
-          <!-- Error -->
-          <div v-if="error" class="alert alert-error text-sm py-2">
-            <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-5 w-5" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
-            <span>{{ error }}</span>
-          </div>
-
-          <!-- Submit -->
-          <button
-            type="submit"
-            class="btn btn-primary w-full"
-            :disabled="isLoading"
-          >
-            <span v-if="isLoading" class="loading loading-spinner loading-sm" />
-            <span v-else>{{ mode === 'login' ? $t('auth.signIn', 'Entrar') : $t('auth.signUp', 'Criar Conta') }}</span>
-          </button>
-        </form>
-
-        <p class="text-center text-base-content/50 text-xs mt-4">
+        <p class="text-center text-base-content/50 text-xs mt-2">
           {{ $t('auth.optional', 'Login é opcional. O app funciona sem conta.') }}
         </p>
 
@@ -145,6 +169,8 @@ useHead({
   title: 'Pomodoro | Login',
 })
 
+const config = useRuntimeConfig()
+const apiBase = config.public.apiBase as string || ''
 const route = useRoute()
 const { login, signUp } = useAuth()
 
@@ -153,8 +179,32 @@ const email = ref('')
 const password = ref('')
 const name = ref('')
 const showPassword = ref(false)
+const showEmailForm = ref(false)
 const isLoading = ref(false)
 const error = ref('')
+const githubEnabled = ref(false)
+
+onMounted(async () => {
+  try {
+    const res = await $fetch<{ enabled: boolean }>(`${apiBase}/api/auth/github-enabled`)
+    githubEnabled.value = res.enabled
+  } catch {
+    githubEnabled.value = false
+  }
+})
+
+async function handleGitHubLogin() {
+  isLoading.value = true
+  error.value = ''
+
+  try {
+    const res = await $fetch<{ url: string }>(`${apiBase}/api/auth/github-login`)
+    navigateTo(res.url, { external: true })
+  } catch {
+    error.value = 'GitHub OAuth não disponível'
+    isLoading.value = false
+  }
+}
 
 async function handleSubmit() {
   error.value = ''


### PR DESCRIPTION
## Resumo

Implementa login/cadastro com GitHub OAuth como opção principal e corrige o alinhamento dos botões do timer Pomodoro.

### GitHub OAuth (Backend)
- ✅ Configuração do GitHub OAuth no Better Auth (services/auth.ts)
- ✅ Novas rotas: /api/auth/github-enabled e /api/auth/github-login
- ✅ Handler do Better Auth montado em /api/better-auth/* para callbacks OAuth
- ✅ Account linking habilitado (mesmo email = mesma conta)

### GitHub OAuth (Frontend)
- ✅ login.vue simplificado: botão GitHub como opção principal
- ✅ Email/senha agora está num accordion colapsível (opção secundária)
- ✅ Navbar: botão "Entrar com GitHub" no dropdown de perfil
- ✅ Composable useAuth com isGitHubUser()

### TimerPresets (Correções visuais)
- ✅ Grid de 3 colunas uniformes (15/25/35/45/60) - botões não desalinhados
- ✅ Input de tempo custom + botão "Aplicar" alinhados
- ✅ Botão "Resetar Timer" com estilo btn-outline consistente

### i18n
- ✅ Novas chaves: loginWithGitHub, emailPassword, or
- ✅ PT-BR e EN atualizados
- ✅ History.vue agora usa locale dinâmico (bonus fix)

### Configuração
Adicionar secrets no Cloudflare:

```bash
wrangler secret put GITHUB_CLIENT_ID
wrangler secret put GITHUB_CLIENT_SECRET
```

### Testes
- ✅ Todos os testes do API passam (11/11)
- ⚠️ 12 testes do web já estavam falhando antes (problema pré-existente com Vue test-utils)

Co-authored-by: Morgana <morgana@openclaw.ai>
