### PR TITLE
fix: correct countdown digit sizing and secondary grid layout

### DIFF
--- a/apps/web/components/atoms/CountdownDigits.vue
+++ b/apps/web/components/atoms/CountdownDigits.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="w-1/2 flex gap-x-2">
+  <div class="flex gap-x-2">
     <span
       v-for="(digit, index) in splittedDigits"
       :key="index"
-      class="w-1/2 bg-base-200 rounded-2xl flex items-center justify-center py-4 text-5xl md:text-7xl lg:text-8xl font-rajdhani font-bold text-base-content shadow-inner"
+      class="flex-1 bg-base-200 rounded-2xl flex items-center justify-center py-4 text-inherit font-rajdhani font-bold text-base-content shadow-inner"
     >
       {{ digit }}
     </span>

--- a/apps/web/pages/index.vue
+++ b/apps/web/pages/index.vue
@@ -97,7 +97,7 @@
     </section>
 
     <!-- SECONDARY: Stats / Spotify -->
-    <section class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+    <section class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
       <CompletedChallenges />
       <SpotifyPlayer />
     </section>


### PR DESCRIPTION
## Problema
O commit #36 (feat: improve main page layout - centered timer hero) introduziu problemas de layout no timer e na grid de conteúdo secundário.

## Problemas encontrados

### 1. CountdownDigits - sizing incorreto
- O componente CountdownDigits usava `w-1/2` tanto no container quanto em cada digito, forcando cada digito para apenas 25% da largura do pai
- Os spans tinham seus proprios tamanhos de fonte (`text-5xl md:text-7xl lg:text-8xl`) que conflitavam com os tamanhos herdados do componente pai Countdown (`lg:text-9xl`)

### 2. Grid de conteudo secundario
- A grid tinha `lg:grid-cols-3` mas apenas 2 itens (CompletedChallenges e SpotifyPlayer), criando uma coluna vazia

## Correcoes

1. **CountdownDigits.vue**:
   - Removido `w-1/2` do container e substituido por `flex` natural
   - Substituido `w-1/2` nos spans por `flex-1` para dimensionamento proporcional
   - Substituido tamanhos de fonte especificos por `text-inherit` para herdar do pai

2. **index.vue**:
   - Alterado `lg:grid-cols-3` para `md:grid-cols-2` na grid de conteudo secundario

## Testes
- 75/75 testes passando
- Build completo sem erros