### PR TITLE
fix: restore PR34 home layout with circular timer and embedded controls

### DIFF
--- a/apps/web/components/molecules/Countdown.vue
+++ b/apps/web/components/molecules/Countdown.vue
@@ -1,25 +1,118 @@
 <template>
   <div class="flex flex-col items-center">
-    <div
-      class="flex justify-center items-center text-6xl sm:text-7xl md:text-8xl lg:text-9xl font-rajdhani font-bold text-base-content tabular-nums"
-    >
-      <CountdownDigits :digits="countdown.minutes" />
-      <span class="px-1 md:px-3 text-primary animate-pulse">:</span>
-      <CountdownDigits :digits="countdown.seconds" />
+    <!-- Circular Timer -->
+    <div class="relative inline-flex items-center justify-center">
+      <svg
+        class="w-56 h-56 sm:w-64 sm:h-64 md:w-72 md:h-72 transform -rotate-90"
+        viewBox="0 0 200 200"
+      >
+        <!-- Background circle -->
+        <circle
+          cx="100"
+          cy="100"
+          r="88"
+          fill="none"
+          stroke-width="6"
+          class="stroke-base-300/50"
+        />
+        <!-- Progress circle -->
+        <circle
+          cx="100"
+          cy="100"
+          r="88"
+          fill="none"
+          stroke-width="6"
+          stroke-linecap="round"
+          :stroke-dasharray="circumference"
+          :stroke-dashoffset="dashOffset"
+          class="stroke-primary transition-all duration-1000 ease-linear"
+        />
+      </svg>
+
+      <!-- Timer content inside circle -->
+      <div class="absolute inset-0 flex flex-col items-center justify-center gap-0 sm:gap-1">
+        <!-- Digits -->
+        <div
+          class="flex justify-center items-center text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-rajdhani font-bold text-base-content tabular-nums"
+        >
+          <CountdownDigits :digits="countdown.minutes" />
+          <span class="px-1 md:px-2 text-primary animate-pulse">:</span>
+          <CountdownDigits :digits="countdown.seconds" />
+        </div>
+
+        <!-- Status text -->
+        <p class="text-xs sm:text-sm text-base-content/50 font-medium -mt-2 sm:-mt-1">
+          {{ countdown.isActive ? $t('timer.inProgress') : $t('timer.ready') }}
+        </p>
+
+        <!-- Control buttons inside circle -->
+        <div class="flex items-center gap-2 sm:gap-3 mt-2 sm:mt-3">
+          <button
+            v-if="countdown.hasCompleted"
+            disabled
+            class="btn btn-disabled btn-xs sm:btn-sm text-xs px-3 sm:px-4"
+          >
+            {{ $t('timer.cycleCompleted') }}
+          </button>
+          <template v-else>
+            <button
+              v-if="!countdown.isActive"
+              class="btn btn-primary btn-xs sm:btn-sm gap-1 sm:gap-2 px-4 sm:px-6 shadow-lg shadow-primary/20 hover:shadow-primary/40 transition-shadow duration-300"
+              @click="$emit('start')"
+            >
+              <svg class="w-3 h-3 sm:w-4 sm:h-4" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M6.3 2.841A1.5 1.5 0 004 4.11V15.89a1.5 1.5 0 002.3 1.269l9.344-5.89a1.5 1.5 0 000-2.538L6.3 2.84z" />
+              </svg>
+              {{ $t('timer.startCycle') }}
+            </button>
+            <button
+              v-else
+              class="btn btn-error btn-outline btn-xs sm:btn-sm gap-1 sm:gap-2 px-4 sm:px-6"
+              @click="$emit('pause')"
+            >
+              <svg class="w-3 h-3 sm:w-4 sm:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              {{ $t('timer.pause') }}
+            </button>
+            <button
+              v-if="countdown.isActive"
+              class="btn btn-ghost btn-xs sm:btn-sm px-2 sm:px-3"
+              @click="$emit('reset')"
+              :title="$t('timer.reset')"
+            >
+              <svg class="w-3 h-3 sm:w-4 sm:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            </button>
+          </template>
+        </div>
+      </div>
     </div>
-    <p class="text-sm text-base-content/50 mt-2 font-medium">
-      {{ countdown.isActive ? $t('timer.inProgress') : $t('timer.ready') }}
-    </p>
   </div>
 </template>
 
 <script setup lang="ts">
-import { watch } from 'vue'
+import { watch, computed } from 'vue'
 import { useCountdownStore } from '~/stores/countdown'
 import CountdownDigits from '~/components/atoms/CountdownDigits.vue'
 
-const emit = defineEmits<{ completed: [] }>()
+const emit = defineEmits<{
+  start: []
+  pause: []
+  reset: []
+  completed: []
+}>()
+
 const countdown = useCountdownStore()
+
+const circumference = 2 * Math.PI * 88
+const progress = computed(() => {
+  const total = countdown.customMinutes * 60
+  if (total === 0) return 0
+  return 1 - (countdown.time / total)
+})
+const dashOffset = computed(() => circumference * (1 - progress.value))
 
 let TIMEOUT_REFERENCE: ReturnType<typeof setTimeout>
 
@@ -35,8 +128,11 @@ function runCountdown(flag: boolean) {
 watch(
   () => countdown.isActive,
   (v) => {
-    runCountdown(v)
-    if (!v) countdown.resetTime()
+    if (v) {
+      runCountdown(true)
+    } else {
+      clearTimeout(TIMEOUT_REFERENCE)
+    }
   },
 )
 
@@ -44,7 +140,10 @@ watch(
   () => countdown.time,
   (v) => {
     if (v > 0) runCountdown(true)
-    else emit('completed')
+    else if (v <= 0 && countdown.isActive) {
+      clearTimeout(TIMEOUT_REFERENCE)
+      emit('completed')
+    }
   },
 )
 </script>

--- a/apps/web/i18n/en.json
+++ b/apps/web/i18n/en.json
@@ -1,166 +1,167 @@
 {
-	"app": {
-		"title": "Pomodoro Move.it",
-		"description": "Pomodoro timer with health and wellness challenges"
-	},
-	"nav": {
-		"level": "Level {level}",
-		"theme": "Theme",
-		"language": "Language",
-		"back": "Back"
-	},
-	"timer": {
-		"startCycle": "Start cycle",
-		"abandonCycle": "Abandon cycle",
-		"cycleCompleted": "Cycle completed",
-		"pomodoroTime": "Pomodoro Time",
-		"customTime": "Custom time (minutes)",
-		"apply": "Apply",
-		"resetTimer": "Reset Timer",
-		"minutes": "{minutes}min",
-		"inProgress": "In progress",
-		"ready": "Ready"
-	},
-	"profile": {
-		"editProfile": "Edit Profile",
-		"githubUsername": "GitHub Username",
-		"githubPlaceholder": "e.g.: Azincourt-tech",
-		"connectedAs": "Connected as {username}",
-		"remove": "Remove",
-		"or": "or",
-		"name": "Name",
-		"namePlaceholder": "Your name",
-		"photoUrl": "Photo URL",
-		"pasteLink": "Paste an image link",
-		"preview": "Preview",
-		"save": "Save",
-		"cancel": "Cancel",
-		"edit": "Edit profile",
-		"defaultName": "User"
-	},
-	"auth": {
-		"signIn": "Sign In",
-		"signUp": "Create Account",
-		"name": "Name",
-		"namePlaceholder": "Your name",
-		"email": "Email",
-		"password": "Password",
-		"passwordPlaceholder": "Your password",
-		"optional": "Login is optional. The app works without an account.",
-		"orContinue": "or continue without account",
-		"skip": "Continue without login",
-		"loggedOut": "You have been logged out",
-		"loginWithGitHub": "Sign in with GitHub",
-		"emailPassword": "Sign in with Email and Password",
-		"or": "or"
-	},
-	"challenges": {
-		"completedChallenges": "Completed challenges",
-		"allChallenges": "All Challenges",
-		"available": "{count} available",
-		"challenges": "challenges",
-		"failed": "Failed",
-		"completed": "Completed",
-		"startCycle": "Start a new cycle to receive new challenges",
-		"levelUp": "Increase your level by completing challenges"
-	},
-	"challengeTypes": {
-		"body": "Stretching",
-		"eye": "Eye Exercise",
-		"drink": "Hydration",
-		"breathe": "Breathing",
-		"posture": "Posture",
-		"meditate": "Quick Meditation",
-		"walk": "Walking"
-	},
-	"levelUp": {
-		"congratulations": "Congratulations!",
-		"newLevel": "You reached a new level!",
-		"continue": "Continue"
-	},
-	"pip": {
-		"closeWindow": "Close floating window",
-		"openWindow": "Open floating window",
-		"inProgress": "In progress",
-		"paused": "Paused",
-		"stop": "Stop",
-		"start": "Start",
-		"reset": "Reset",
-		"challenge": "Challenge",
-		"startForChallenges": "Start a cycle to receive challenges",
-		"allowPopups": "Allow popups to use the floating window"
-	},
-	"spotify": {
-		"player": "Spotify Player",
-		"playlistLink": "Playlist link...",
-		"use": "Use",
-		"activePlaylist": "Active playlist",
-		"remove": "Remove",
-		"loginInfo": "To listen to full songs, log in to your Spotify account in the browser",
-		"pasteLink": "Paste a Spotify link"
-	},
-	"experience": {
-		"xp": "xp"
-	},
-	"footer": {
-		"madeBy": "Made by"
-	},
-	"notifications": {
-		"cycleCompleted": "Cycle completed!",
-		"newChallenge": "New challenge available!"
-	},
-	"shortcuts": {
-		"title": "Keyboard Shortcuts",
-		"togglePlay": "Start / Pause",
-		"reset": "Reset timer",
-		"nextChallenge": "Next challenge",
-		"focusMode": "Focus mode",
-		"showHelp": "Show shortcuts",
-		"close": "Close"
-	},
-	"history": {
-		"title": "History",
-		"navLink": "History",
-		"totalSessions": "Total sessions",
-		"totalTime": "Total focused time",
-		"avgDaily": "Daily average",
-		"noSessions": "No sessions recorded yet",
-		"today": "Today",
-		"yesterday": "Yesterday",
-		"thisWeek": "This week",
-		"older": "Older",
-		"sessionCompleted": "Session completed",
-		"xpGained": "+{xp} xp",
-		"minutes": "{minutes} min",
-		"days": "{days} days"
-	},
-	"streak": {
-		"title": "Streak",
-		"current": "{days} days",
-		"best": "Best: {days} days"
-	},
-	"focusMode": {
-		"exit": "Exit focus mode (ESC)",
-		"title": "Focus Mode"
-	},
-	"share": {
-		"title": "Share",
-		"button": "Share result",
-		"download": "Download image"
-	},
-	"sound": {
-		"toggle": "Sounds",
-		"enabled": "Sounds enabled",
-		"disabled": "Sounds disabled"
-	},
-	"sync": {
-		"login": "Login",
-		"logout": "Logout",
-		"syncing": "Syncing...",
-		"synced": "Synced",
-		"error": "Sync error"
-	},
-	"pwa": {
-		"install": "Install App"
-	}
+  "app": {
+    "title": "Pomodoro Move.it",
+    "description": "Pomodoro timer with health and wellness challenges"
+  },
+  "nav": {
+    "level": "Level {level}",
+    "theme": "Theme",
+    "language": "Language",
+    "back": "Back"
+  },
+  "timer": {
+    "startCycle": "Start cycle",
+    "abandonCycle": "Abandon cycle",
+    "cycleCompleted": "Cycle completed",
+    "pomodoroTime": "Pomodoro Time",
+    "customTime": "Custom time (minutes)",
+    "apply": "Apply",
+    "resetTimer": "Reset Timer",
+    "minutes": "{minutes}min",
+    "inProgress": "In progress",
+    "ready": "Ready",
+    "pause": "Pause"
+  },
+  "profile": {
+    "editProfile": "Edit Profile",
+    "githubUsername": "GitHub Username",
+    "githubPlaceholder": "e.g.: Azincourt-tech",
+    "connectedAs": "Connected as {username}",
+    "remove": "Remove",
+    "or": "or",
+    "name": "Name",
+    "namePlaceholder": "Your name",
+    "photoUrl": "Photo URL",
+    "pasteLink": "Paste an image link",
+    "preview": "Preview",
+    "save": "Save",
+    "cancel": "Cancel",
+    "edit": "Edit profile",
+    "defaultName": "User"
+  },
+  "auth": {
+    "signIn": "Sign In",
+    "signUp": "Create Account",
+    "name": "Name",
+    "namePlaceholder": "Your name",
+    "email": "Email",
+    "password": "Password",
+    "passwordPlaceholder": "Your password",
+    "optional": "Login is optional. The app works without an account.",
+    "orContinue": "or continue without account",
+    "skip": "Continue without login",
+    "loggedOut": "You have been logged out",
+    "loginWithGitHub": "Sign in with GitHub",
+    "emailPassword": "Sign in with Email and Password",
+    "or": "or"
+  },
+  "challenges": {
+    "completedChallenges": "Completed challenges",
+    "allChallenges": "All Challenges",
+    "available": "{count} available",
+    "challenges": "challenges",
+    "failed": "Failed",
+    "completed": "Completed",
+    "startCycle": "Start a new cycle to receive new challenges",
+    "levelUp": "Increase your level by completing challenges"
+  },
+  "challengeTypes": {
+    "body": "Stretching",
+    "eye": "Eye Exercise",
+    "drink": "Hydration",
+    "breathe": "Breathing",
+    "posture": "Posture",
+    "meditate": "Quick Meditation",
+    "walk": "Walking"
+  },
+  "levelUp": {
+    "congratulations": "Congratulations!",
+    "newLevel": "You reached a new level!",
+    "continue": "Continue"
+  },
+  "pip": {
+    "closeWindow": "Close floating window",
+    "openWindow": "Open floating window",
+    "inProgress": "In progress",
+    "paused": "Paused",
+    "stop": "Stop",
+    "start": "Start",
+    "reset": "Reset",
+    "challenge": "Challenge",
+    "startForChallenges": "Start a cycle to receive challenges",
+    "allowPopups": "Allow popups to use the floating window"
+  },
+  "spotify": {
+    "player": "Spotify Player",
+    "playlistLink": "Playlist link...",
+    "use": "Use",
+    "activePlaylist": "Active playlist",
+    "remove": "Remove",
+    "loginInfo": "To listen to full songs, log in to your Spotify account in the browser",
+    "pasteLink": "Paste a Spotify link"
+  },
+  "experience": {
+    "xp": "xp"
+  },
+  "footer": {
+    "madeBy": "Made by"
+  },
+  "notifications": {
+    "cycleCompleted": "Cycle completed!",
+    "newChallenge": "New challenge available!"
+  },
+  "shortcuts": {
+    "title": "Keyboard Shortcuts",
+    "togglePlay": "Start / Pause",
+    "reset": "Reset timer",
+    "nextChallenge": "Next challenge",
+    "focusMode": "Focus mode",
+    "showHelp": "Show shortcuts",
+    "close": "Close"
+  },
+  "history": {
+    "title": "History",
+    "navLink": "History",
+    "totalSessions": "Total sessions",
+    "totalTime": "Total focused time",
+    "avgDaily": "Daily average",
+    "noSessions": "No sessions recorded yet",
+    "today": "Today",
+    "yesterday": "Yesterday",
+    "thisWeek": "This week",
+    "older": "Older",
+    "sessionCompleted": "Session completed",
+    "xpGained": "+{xp} xp",
+    "minutes": "{minutes} min",
+    "days": "{days} days"
+  },
+  "streak": {
+    "title": "Streak",
+    "current": "{days} days",
+    "best": "Best: {days} days"
+  },
+  "focusMode": {
+    "exit": "Exit focus mode (ESC)",
+    "title": "Focus Mode"
+  },
+  "share": {
+    "title": "Share",
+    "button": "Share result",
+    "download": "Download image"
+  },
+  "sound": {
+    "toggle": "Sounds",
+    "enabled": "Sounds enabled",
+    "disabled": "Sounds disabled"
+  },
+  "sync": {
+    "login": "Login",
+    "logout": "Logout",
+    "syncing": "Syncing...",
+    "synced": "Synced",
+    "error": "Sync error"
+  },
+  "pwa": {
+    "install": "Install App"
+  }
 }

--- a/apps/web/i18n/pt-BR.json
+++ b/apps/web/i18n/pt-BR.json
@@ -1,166 +1,167 @@
 {
-	"app": {
-		"title": "Pomodoro Move.it",
-		"description": "Pomodoro timer com desafios de saude e bem-estar"
-	},
-	"nav": {
-		"level": "Level {level}",
-		"theme": "Tema",
-		"language": "Idioma",
-		"back": "Voltar"
-	},
-	"timer": {
-		"startCycle": "Iniciar ciclo",
-		"abandonCycle": "Abandonar ciclo",
-		"cycleCompleted": "Ciclo completado",
-		"pomodoroTime": "Tempo do Pomodoro",
-		"customTime": "Tempo personalizado (minutos)",
-		"apply": "Aplicar",
-		"resetTimer": "Resetar Timer",
-		"minutes": "{minutes}min",
-		"inProgress": "Em andamento",
-		"ready": "Pronto"
-	},
-	"profile": {
-		"editProfile": "Editar Perfil",
-		"githubUsername": "Username do GitHub",
-		"githubPlaceholder": "ex: Azincourt-tech",
-		"connectedAs": "Conectado como {username}",
-		"remove": "Remover",
-		"or": "ou",
-		"name": "Nome",
-		"namePlaceholder": "Seu nome",
-		"photoUrl": "URL da foto",
-		"pasteLink": "Cole o link de uma imagem",
-		"preview": "Preview",
-		"save": "Salvar",
-		"cancel": "Cancelar",
-		"edit": "Editar perfil",
-		"defaultName": "Usuario"
-	},
-	"auth": {
-		"signIn": "Entrar",
-		"signUp": "Criar Conta",
-		"name": "Nome",
-		"namePlaceholder": "Seu nome",
-		"email": "E-mail",
-		"password": "Senha",
-		"passwordPlaceholder": "Sua senha",
-		"optional": "Login e opcional. O app funciona sem conta.",
-		"orContinue": "ou continue sem conta",
-		"skip": "Continuar sem login",
-		"loggedOut": "Voce saiu da sua conta",
-		"loginWithGitHub": "Entrar com GitHub",
-		"emailPassword": "Entrar com E-mail e Senha",
-		"or": "ou"
-	},
-	"challenges": {
-		"completedChallenges": "Desafios completados",
-		"allChallenges": "Todos os Challenges",
-		"available": "{count} disponiveis",
-		"challenges": "challenges",
-		"failed": "Falhou",
-		"completed": "Completou",
-		"startCycle": "Inicie um ciclo para receber novos desafios",
-		"levelUp": "Aumente seu nivel completando os desafios"
-	},
-	"challengeTypes": {
-		"body": "Alongamento",
-		"eye": "Exercicio Ocular",
-		"drink": "Hidratacao",
-		"breathe": "Respiracao",
-		"posture": "Postura",
-		"meditate": "Meditacao Rapida",
-		"walk": "Caminhada"
-	},
-	"levelUp": {
-		"congratulations": "Parabens!",
-		"newLevel": "Voce alcancou um novo nivel!",
-		"continue": "Continuar"
-	},
-	"pip": {
-		"closeWindow": "Fechar janela flutuante",
-		"openWindow": "Abrir janela flutuante",
-		"inProgress": "Em andamento",
-		"paused": "Pausado",
-		"stop": "Parar",
-		"start": "Iniciar",
-		"reset": "Reset",
-		"challenge": "Desafio",
-		"startForChallenges": "Inicie um ciclo para receber desafios",
-		"allowPopups": "Permita popups para usar a janela flutuante"
-	},
-	"spotify": {
-		"player": "Spotify Player",
-		"playlistLink": "Link da playlist...",
-		"use": "Usar",
-		"activePlaylist": "Playlist ativa",
-		"remove": "Remover",
-		"loginInfo": "Para ouvir as musicas completas, faca login na sua conta do Spotify no navegador",
-		"pasteLink": "Cole um link do Spotify"
-	},
-	"experience": {
-		"xp": "xp"
-	},
-	"footer": {
-		"madeBy": "Feito por"
-	},
-	"notifications": {
-		"cycleCompleted": "Ciclo completado!",
-		"newChallenge": "Novo desafio disponivel!"
-	},
-	"shortcuts": {
-		"title": "Atalhos de Teclado",
-		"togglePlay": "Iniciar / Pausar",
-		"reset": "Resetar timer",
-		"nextChallenge": "Proximo desafio",
-		"focusMode": "Modo foco",
-		"showHelp": "Mostrar atalhos",
-		"close": "Fechar"
-	},
-	"history": {
-		"title": "Historico",
-		"navLink": "Historico",
-		"totalSessions": "Total de sessoes",
-		"totalTime": "Tempo total focado",
-		"avgDaily": "Media diaria",
-		"noSessions": "Nenhuma sessao registrada ainda",
-		"today": "Hoje",
-		"yesterday": "Ontem",
-		"thisWeek": "Esta semana",
-		"older": "Mais antigas",
-		"sessionCompleted": "Sessao completada",
-		"xpGained": "+{xp} xp",
-		"minutes": "{minutes} min",
-		"days": "{days} dias"
-	},
-	"streak": {
-		"title": "Sequencia",
-		"current": "{days} dias",
-		"best": "Melhor: {days} dias"
-	},
-	"focusMode": {
-		"exit": "Sair do modo foco (ESC)",
-		"title": "Modo Foco"
-	},
-	"share": {
-		"title": "Compartilhar",
-		"button": "Compartilhar resultado",
-		"download": "Baixar imagem"
-	},
-	"sound": {
-		"toggle": "Sons",
-		"enabled": "Sons ativados",
-		"disabled": "Sons desativados"
-	},
-	"sync": {
-		"login": "Entrar",
-		"logout": "Sair",
-		"syncing": "Sincronizando...",
-		"synced": "Sincronizado",
-		"error": "Erro ao sincronizar"
-	},
-	"pwa": {
-		"install": "Instalar App"
-	}
+  "app": {
+    "title": "Pomodoro Move.it",
+    "description": "Pomodoro timer com desafios de saude e bem-estar"
+  },
+  "nav": {
+    "level": "Level {level}",
+    "theme": "Tema",
+    "language": "Idioma",
+    "back": "Voltar"
+  },
+  "timer": {
+    "startCycle": "Iniciar ciclo",
+    "abandonCycle": "Abandonar ciclo",
+    "cycleCompleted": "Ciclo completado",
+    "pomodoroTime": "Tempo do Pomodoro",
+    "customTime": "Tempo personalizado (minutos)",
+    "apply": "Aplicar",
+    "resetTimer": "Resetar Timer",
+    "minutes": "{minutes}min",
+    "inProgress": "Em andamento",
+    "ready": "Pronto",
+    "pause": "Pausar"
+  },
+  "profile": {
+    "editProfile": "Editar Perfil",
+    "githubUsername": "Username do GitHub",
+    "githubPlaceholder": "ex: Azincourt-tech",
+    "connectedAs": "Conectado como {username}",
+    "remove": "Remover",
+    "or": "ou",
+    "name": "Nome",
+    "namePlaceholder": "Seu nome",
+    "photoUrl": "URL da foto",
+    "pasteLink": "Cole o link de uma imagem",
+    "preview": "Preview",
+    "save": "Salvar",
+    "cancel": "Cancelar",
+    "edit": "Editar perfil",
+    "defaultName": "Usuario"
+  },
+  "auth": {
+    "signIn": "Entrar",
+    "signUp": "Criar Conta",
+    "name": "Nome",
+    "namePlaceholder": "Seu nome",
+    "email": "E-mail",
+    "password": "Senha",
+    "passwordPlaceholder": "Sua senha",
+    "optional": "Login e opcional. O app funciona sem conta.",
+    "orContinue": "ou continue sem conta",
+    "skip": "Continuar sem login",
+    "loggedOut": "Voce saiu da sua conta",
+    "loginWithGitHub": "Entrar com GitHub",
+    "emailPassword": "Entrar com E-mail e Senha",
+    "or": "ou"
+  },
+  "challenges": {
+    "completedChallenges": "Desafios completados",
+    "allChallenges": "Todos os Challenges",
+    "available": "{count} disponiveis",
+    "challenges": "challenges",
+    "failed": "Falhou",
+    "completed": "Completou",
+    "startCycle": "Inicie um ciclo para receber novos desafios",
+    "levelUp": "Aumente seu nivel completando os desafios"
+  },
+  "challengeTypes": {
+    "body": "Alongamento",
+    "eye": "Exercicio Ocular",
+    "drink": "Hidratacao",
+    "breathe": "Respiracao",
+    "posture": "Postura",
+    "meditate": "Meditacao Rapida",
+    "walk": "Caminhada"
+  },
+  "levelUp": {
+    "congratulations": "Parabens!",
+    "newLevel": "Voce alcancou um novo nivel!",
+    "continue": "Continuar"
+  },
+  "pip": {
+    "closeWindow": "Fechar janela flutuante",
+    "openWindow": "Abrir janela flutuante",
+    "inProgress": "Em andamento",
+    "paused": "Pausado",
+    "stop": "Parar",
+    "start": "Iniciar",
+    "reset": "Reset",
+    "challenge": "Desafio",
+    "startForChallenges": "Inicie um ciclo para receber desafios",
+    "allowPopups": "Permita popups para usar a janela flutuante"
+  },
+  "spotify": {
+    "player": "Spotify Player",
+    "playlistLink": "Link da playlist...",
+    "use": "Usar",
+    "activePlaylist": "Playlist ativa",
+    "remove": "Remover",
+    "loginInfo": "Para ouvir as musicas completas, faca login na sua conta do Spotify no navegador",
+    "pasteLink": "Cole um link do Spotify"
+  },
+  "experience": {
+    "xp": "xp"
+  },
+  "footer": {
+    "madeBy": "Feito por"
+  },
+  "notifications": {
+    "cycleCompleted": "Ciclo completado!",
+    "newChallenge": "Novo desafio disponivel!"
+  },
+  "shortcuts": {
+    "title": "Atalhos de Teclado",
+    "togglePlay": "Iniciar / Pausar",
+    "reset": "Resetar timer",
+    "nextChallenge": "Proximo desafio",
+    "focusMode": "Modo foco",
+    "showHelp": "Mostrar atalhos",
+    "close": "Fechar"
+  },
+  "history": {
+    "title": "Historico",
+    "navLink": "Historico",
+    "totalSessions": "Total de sessoes",
+    "totalTime": "Tempo total focado",
+    "avgDaily": "Media diaria",
+    "noSessions": "Nenhuma sessao registrada ainda",
+    "today": "Hoje",
+    "yesterday": "Ontem",
+    "thisWeek": "Esta semana",
+    "older": "Mais antigas",
+    "sessionCompleted": "Sessao completada",
+    "xpGained": "+{xp} xp",
+    "minutes": "{minutes} min",
+    "days": "{days} dias"
+  },
+  "streak": {
+    "title": "Sequencia",
+    "current": "{days} dias",
+    "best": "Melhor: {days} dias"
+  },
+  "focusMode": {
+    "exit": "Sair do modo foco (ESC)",
+    "title": "Modo Foco"
+  },
+  "share": {
+    "title": "Compartilhar",
+    "button": "Compartilhar resultado",
+    "download": "Baixar imagem"
+  },
+  "sound": {
+    "toggle": "Sons",
+    "enabled": "Sons ativados",
+    "disabled": "Sons desativados"
+  },
+  "sync": {
+    "login": "Entrar",
+    "logout": "Sair",
+    "syncing": "Sincronizando...",
+    "synced": "Sincronizado",
+    "error": "Erro ao sincronizar"
+  },
+  "pwa": {
+    "install": "Instalar App"
+  }
 }

--- a/apps/web/pages/index.vue
+++ b/apps/web/pages/index.vue
@@ -29,91 +29,62 @@
     <!-- PiP Window -->
     <PiPWindow />
 
-    <!-- 3-Column Layout -->
-    <div class="grid grid-cols-1 lg:grid-cols-12 gap-6 lg:gap-8">
-      <!-- LEFT: Profile + Stats -->
-      <aside class="lg:col-span-3 flex flex-col gap-4">
-        <Profile />
-        <CompletedChallenges />
-      </aside>
+    <!-- Centered single column layout -->
+    <div class="max-w-2xl mx-auto flex flex-col items-center gap-6 lg:gap-8">
+      <!-- Timer (circular with buttons inside) -->
+      <Countdown
+        @start="handleStart"
+        @pause="handlePause"
+        @reset="handleReset"
+        @completed="getNewChallenge"
+      />
 
-      <!-- CENTER: Timer + Challenge -->
-      <main class="lg:col-span-6 flex flex-col items-center gap-6">
-        <!-- Countdown Display -->
-        <Countdown @completed="getNewChallenge" />
-
-        <!-- Timer Presets (mobile only) -->
-        <div class="w-full max-w-md lg:hidden">
-          <TimerPresets />
-        </div>
-
-        <!-- Action Buttons -->
-        <div class="w-full max-w-xs">
-          <button
-            v-if="countdown.hasCompleted"
-            disabled
-            class="btn btn-disabled btn-block h-14 text-base font-semibold rounded-xl"
-          >
-            {{ $t('timer.cycleCompleted') }}
-          </button>
-          <button
-            v-else-if="countdown.isActive"
-            class="btn btn-error btn-outline btn-block h-14 text-base font-semibold rounded-xl"
-            @click="setCountdownState(false)"
-          >
-            {{ $t('timer.abandonCycle') }}
-          </button>
-          <button
-            v-else
-            class="btn btn-primary btn-block h-14 text-base font-semibold rounded-xl shadow-lg shadow-primary/20 hover:shadow-primary/40 transition-shadow duration-300"
-            @click="setCountdownState(true)"
-          >
-            {{ $t('timer.startCycle') }}
-          </button>
-        </div>
-
-        <!-- Share button after completion -->
-        <div
-          v-if="countdown.hasCompleted"
-          class="w-full max-w-xs"
+      <!-- Share button after completion -->
+      <div
+        v-if="countdown.hasCompleted"
+        class="w-full max-w-sm"
+      >
+        <button
+          class="btn btn-outline btn-block h-12 text-base font-semibold rounded-xl"
+          @click="showShareCard"
         >
-          <button
-            class="btn btn-outline btn-block h-12 text-base font-semibold rounded-xl"
-            @click="showShareCard"
+          <svg
+            class="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
           >
-            <svg
-              class="w-5 h-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
-              />
-            </svg>
-            {{ $t('share.button') }}
-          </button>
-        </div>
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
+            />
+          </svg>
+          {{ $t('share.button') }}
+        </button>
+      </div>
 
-        <!-- Challenge Card -->
-        <div class="w-full">
-          <Card id="challenge" />
-        </div>
+      <!-- Ciclos Completos + Presets (side by side) -->
+      <div class="w-full grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <CompletedChallenges />
+        <TimerPresets />
+      </div>
 
-        <!-- Challenges Browser -->
-        <div class="w-full">
-          <ChallengeBrowser />
-        </div>
-      </main>
+      <!-- Challenge Card -->
+      <div class="w-full">
+        <Card id="challenge" />
+      </div>
 
-      <!-- RIGHT: TimerPresets (desktop) + Spotify -->
-      <aside class="lg:col-span-3 flex flex-col gap-4">
-        <TimerPresets class="hidden lg:flex" />
-        <SpotifyPlayer class="flex-1" />
-      </aside>
+      <!-- Challenges Browser -->
+      <div class="w-full">
+        <ChallengeBrowser />
+      </div>
+
+      <!-- Spotify Player -->
+      <div class="w-full">
+        <SpotifyPlayer />
+      </div>
     </div>
 
     <!-- Share Card Modal -->
@@ -138,7 +109,6 @@ import TimerPresets from '~/components/atoms/TimerPresets.vue'
 import SpotifyPlayer from '~/components/atoms/SpotifyPlayer.vue'
 import ChallengeBrowser from '~/components/atoms/ChallengeBrowser.vue'
 import PiPWindow from '~/components/atoms/PiPWindow.vue'
-import Profile from '~/components/molecules/Profile.vue'
 import Countdown from '~/components/molecules/Countdown.vue'
 import Card from '~/components/organisms/Card.vue'
 import ShareCard from '~/components/molecules/ShareCard.vue'
@@ -184,15 +154,22 @@ function requestNotificationPermission() {
   }
 }
 
-function setCountdownState(flag: boolean) {
+function handleStart() {
   countdown.setHasCompleted(false)
-  countdown.setIsActive(flag)
-  if (flag) {
-    sessionStartTime.value = Date.now()
-    playStart()
-  } else {
-    playPause()
-  }
+  countdown.setIsActive(true)
+  sessionStartTime.value = Date.now()
+  playStart()
+}
+
+function handlePause() {
+  countdown.setIsActive(false)
+  playPause()
+}
+
+function handleReset() {
+  countdown.setIsActive(false)
+  countdown.setHasCompleted(false)
+  countdown.resetTime()
 }
 
 function getNewChallenge() {
@@ -260,12 +237,14 @@ function toggleFocusMode() {
 useKeyboardShortcuts({
   onTogglePlay: () => {
     if (countdown.hasCompleted) return
-    setCountdownState(!countdown.isActive)
+    if (countdown.isActive) {
+      handlePause()
+    } else {
+      handleStart()
+    }
   },
   onReset: () => {
-    countdown.setIsActive(false)
-    countdown.setHasCompleted(false)
-    countdown.resetTime()
+    handleReset()
   },
   onNextChallenge: () => {
     const index = getRandomNumber(0, challenges.challengesLength)


### PR DESCRIPTION
## Summary
- Restored single-column centered layout from PR #34 (commit 837bdac)
- Added circular SVG progress ring to Countdown component with progress tracking
- Embedded Start/Pause/Reset buttons inside the timer circle (not separate)
- Side-by-side cards: CompletedChallenges + TimerPresets below the timer
- Challenge card, ChallengeBrowser, SpotifyPlayer stacked vertically below
- Clean, non-wasteful layout without column spreading

## Preserved Features
- GitHub OAuth login (PR #35)
- Web Audio API sounds
- Session history
- Streak tracking
- PWA install support
- Keyboard shortcuts
- All i18n translations

## Changes
- `apps/web/pages/index.vue` - New single-column layout
- `apps/web/components/molecules/Countdown.vue` - Circular progress ring + embedded controls
- `apps/web/i18n/pt-BR.json` - Added `timer.pause` key
- `apps/web/i18n/en.json` - Added `timer.pause` key

## Tests
- Build: passing ✓
- Tests: 75/75 passing ✓